### PR TITLE
Bug fixes + Disable queue on the fly!

### DIFF
--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -341,6 +341,7 @@ void Config::Load()
     write_config = false;
   }
 
+  this->queue_enabled       = get_config_or_default(config, parsed, "control", "queue_enabled", true);
   this->hotkeys_enabled     = get_config_or_default(config, parsed, "control", "hotkeys_enabled", true);
   this->hotkeys_extended    = get_config_or_default(config, parsed, "control", "hotkeys_extended", true);
   this->use_scopely_hotkeys = get_config_or_default(config, parsed, "control", "use_scopely_hotkeys", false);
@@ -498,7 +499,7 @@ void Config::Load()
 
   parse_config_shortcut(config, parsed, "action_primary", GameFunction::ActionPrimary, "SPACE");
   parse_config_shortcut(config, parsed, "action_secondary", GameFunction::ActionSecondary, "R");
-  parse_config_shortcut(config, parsed, "action_queue", GameFunction::ActionQueue, "V");
+  parse_config_shortcut(config, parsed, "action_queue", GameFunction::ActionQueue, "ALT-Q");
   parse_config_shortcut(config, parsed, "action_view", GameFunction::ActionView, "V");
   parse_config_shortcut(config, parsed, "action_recall", GameFunction::ActionRecall, "R");
   parse_config_shortcut(config, parsed, "action_recall_cancel", GameFunction::ActionRecallCancel, "SPACE");
@@ -564,12 +565,13 @@ void Config::Load()
     parse_config_shortcut(config, parsed, "set_zoom_preset5", GameFunction::SetZoomPreset5, "SHIFT-F5");
     parse_config_shortcut(config, parsed, "set_zoom_default", GameFunction::SetZoomDefault, "CTRL-=");
     parse_config_shortcut(config, parsed, "toggle_preview_locate", GameFunction::TogglePreviewLocate, "CTRL-L");
-    parse_config_shortcut(config, parsed, "toggle_preview_locate", GameFunction::TogglePreviewRecall, "CTRL-R");
+    parse_config_shortcut(config, parsed, "toggle_preview_recall", GameFunction::TogglePreviewRecall, "CTRL-R");
     parse_config_shortcut(config, parsed, "toggle_cargo_default", GameFunction::ToggleCargoDefault, "ALT-1");
     parse_config_shortcut(config, parsed, "toggle_cargo_player", GameFunction::ToggleCargoPlayer, "ALT-2");
     parse_config_shortcut(config, parsed, "toggle_cargo_station", GameFunction::ToggleCargoStation, "ALT-3");
     parse_config_shortcut(config, parsed, "toggle_cargo_hostile", GameFunction::ToggleCargoHostile, "ALT-4");
     parse_config_shortcut(config, parsed, "toggle_cargo_armada", GameFunction::ToggleCargoArmada, "ALT-5");
+    parse_config_shortcut(config, parsed, "toggle_queue", GameFunction::ToggleQueue, "CTRL-Q");
   }
 
   if (!std::filesystem::exists(File::MakePath(File::Config()))) {

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -42,6 +42,7 @@ public:
 
   float keyboard_zoom_speed;
 
+  bool  queue_enabled;
   bool  hotkeys_enabled;
   bool  hotkeys_extended;
   bool  use_scopely_hotkeys;

--- a/mods/src/file.cc
+++ b/mods/src/file.cc
@@ -149,7 +149,7 @@ std::wstring File::Title()
 #endif
 
     if (File::override && !title.empty()) {
-      cacheNameTitle = L"[" + File::Path().replace_extension().wstring() + L"] " + title;
+      cacheNameTitle = L"[" + File::Path().filename().replace_extension().wstring() + L"] " + title;
     }
   }
 

--- a/mods/src/patches/gamefunctions.h
+++ b/mods/src/patches/gamefunctions.h
@@ -73,6 +73,7 @@ enum GameFunction {
   SetZoomDefault,
   DisableHotKeys,
   EnableHotKeys,
+  ToggleQueue,
   TogglePreviewLocate,
   TogglePreviewRecall,
   ToggleCargoDefault,

--- a/mods/src/patches/parts/buff_fixes.cc
+++ b/mods/src/patches/parts/buff_fixes.cc
@@ -139,7 +139,7 @@ void InstallBuffFixHooks()
   } else {
     auto ptr = fleethelper.GetMethod("ResolveOfficerAbilityBuffs");
     if (ptr == nullptr) {
-      ErrorMsg::MissingMethod("FleetService", "IsBuffConditionMet");
+      ErrorMsg::MissingMethod("FleetService", "ResolveOfficerAbilityBuffs");
     } else {
       SPUD_STATIC_DETOUR(ptr, FleetService_ResolveOfficerAbilityBuffs_Hook);
     }

--- a/mods/src/patches/parts/free_resize.cc
+++ b/mods/src/patches/parts/free_resize.cc
@@ -106,7 +106,7 @@ struct ResolutionArray {
 
 void AspectRatioConstraintHandler_Update(auto original, void* _this)
 {
-  static auto set_title       = false;
+  static auto set_title       = true;
   static auto get_fullscreen  = il2cpp_resolve_icall_typed<bool()>("UnityEngine.Screen::get_fullScreen()");
   static auto get_height      = il2cpp_resolve_icall_typed<int()>("UnityEngine.Screen::get_height()");
   static auto get_width       = il2cpp_resolve_icall_typed<int()>("UnityEngine.Screen::get_width()");
@@ -137,10 +137,14 @@ void AspectRatioConstraintHandler_Update(auto original, void* _this)
   }
 
 #if _WIN32
-  HWND hwnd = Config::WindowHandle();
-  auto title = File::Title();
-  if (hwnd != nullptr && !set_title && !title.empty()) {
-    set_title = SetWindowTextW(hwnd, title.c_str());
+  if (set_title) {
+    HWND hwnd  = Config::WindowHandle();
+    auto title = File::Title();
+    if (hwnd != nullptr && !title.empty()) {
+      if (SetWindowTextW(hwnd, title.c_str())) {
+        set_title = false;
+      }
+    }
   }
 #endif
 

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -188,6 +188,11 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
 
   if (!is_in_chat) {
     if (!Key::IsInputFocused()) {
+      if ((MapKey::IsDown(GameFunction::ToggleQueue))) {
+        config->queue_enabled = !config->queue_enabled;
+        return;
+      }
+
       if ((MapKey::IsDown(GameFunction::ShowChat) || MapKey::IsDown(GameFunction::ShowChatSide1)
            || MapKey::IsDown(GameFunction::ShowChatSide2))) {
         if (auto chat_manager = ChatManager::Instance(); chat_manager) {
@@ -204,6 +209,20 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
           } else {
             chat_manager->OpenChannel(ChatChannelCategory::Alliance, ChatViewMode::Fullscreen);
           }
+        }
+      }
+
+      if (MapKey::IsDown(GameFunction::MoveLeft)) {
+        auto const result = MoveOfficerCanvas(true);
+        if (result) {
+          return;
+        }
+      }
+
+      if (MapKey::IsDown(GameFunction::MoveRight)) {
+        auto const result = MoveOfficerCanvas(false);
+        if (result) {
+          return;
         }
       }
 


### PR DESCRIPTION
This update fixes a couple of minor issues, ensures the title is based solely on filename (no path info) and now allows you to disable the Kir'Shira artifact queue on the fly using CTRL-Q!