### PR TITLE
change to static build to avoid vc runtime dependencies

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -2,6 +2,8 @@ set_project("stfc-community-patch")
 
 set_languages("c++20")
 
+set_runtimes("MT") -- Set the default build to multi-threaded static
+
 add_requires("eastl")
 add_requires("spdlog")
 add_requires("toml++")


### PR DESCRIPTION
Switching to a static build should resolve the issues with VC runtime version dependencies on both Windows and Wine.  Tashcan's suggestion.