### PR TITLE
Chat hotkey fixes

### DIFF
--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -344,14 +344,6 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
         return chat_manager->OpenChannel(ChatChannelCategory::Private);
       }
     }
-
-    if (MapKey::IsDown(GameFunction::ActionView)) {
-      if (auto view_controller = ObjectFinder<FullScreenChatViewController>::Get(); view_controller) {
-        if (view_controller->_messageList && view_controller->_messageList->_inputField) {
-          return view_controller->_messageList->_inputField->ActivateInputField();
-        }
-      }
-    }
   }
 
   if (!Key::IsInputFocused()) {

--- a/mods/src/prime/ChatManager.h
+++ b/mods/src/prime/ChatManager.h
@@ -9,11 +9,12 @@
 enum class ChatChannelCategory // TypeDefIndex: 11600
 {
   None            = -1,
-  Global          = 0,
-  Alliance        = 1,
-  Private         = 2,
-  Private_Message = 3,
-  Block           = 4
+  Cadet           = 0,
+  Global          = 1,
+  Alliance        = 2,
+  Private         = 3,
+  Private_Message = 4,
+  Block           = 5
 };
 
 enum class ChatViewMode {


### PR DESCRIPTION
Two fixes for hotkeys in chat:
1) Adjust indexes for chat channels due to addition of Cadet chat in patch 78.  Allows chat channel selection hotkeys (^1, ^2, ^3) to work as expected.  (TODO: IsInChat() should also be updated to include Cadet chat, but this requires a SectionID enum definition in Hub.cc, and I'm not sure how to extract that.)
2) Remove ActionView keybind handling in chat.  It interferes with the emoji search function and does not seem to be needed any more (input box has been active when chat appears in all testing i've been able to do).  If retained, it should probably have a different keybind than ActionView, which is primarily for toggling target view modes, and code to disable it while emoji popup is active would be needed.
