### PR TITLE
Version string substitution for MacOS build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ debug.log
 /.xmake/
 /vsxmake*/
 .DS_Store
+
+# Generated Info.plist files (generated from templates)
+**/Info.plist

--- a/docs/VERSION_SUBSTITUTION.md
+++ b/docs/VERSION_SUBSTITUTION.md
@@ -1,0 +1,87 @@
+# Version Substitution in macOS Launcher
+
+## Overview
+
+The macOS launcher's `Info.plist` file now automatically uses the version defined in `mods/src/version.h` during the build process. This ensures consistency between the application version and the mod version.
+
+## Implementation
+
+### Files Involved
+
+- **Template**: `macos-launcher/src/Info.plist.template` - Contains version placeholders
+- **Generated**: `macos-launcher/src/Info.plist` - Generated during build (not committed to git)
+- **Source**: `mods/src/version.h` - Contains version definitions
+- **Build**: `macos-launcher/xmake.lua` - Contains version extraction and substitution logic
+
+### Version Extraction
+
+The build process extracts version components from `mods/src/version.h`:
+
+```c
+#define VERSION_MAJOR     0
+#define VERSION_MINOR     6  
+#define VERSION_REVISION  1
+#define VERSION_PATCH     7
+```
+
+These are combined into a version string like `0.6.1.7`.
+
+### Template Processing
+
+The `Info.plist.template` uses `${VERSION}` placeholders:
+
+```xml
+<key>CFBundleShortVersionString</key>
+<string>${VERSION}</string>
+<key>CFBundleVersion</key>
+<string>${VERSION}</string>
+```
+
+During build, these placeholders are replaced with the actual version.
+
+## Build Process
+
+1. **Configuration Phase**: `on_config` function in xmake.lua executes
+2. **Version Extraction**: Reads and parses `mods/src/version.h`
+3. **Template Processing**: Replaces `${VERSION}` in template with extracted version
+4. **File Generation**: Writes processed `Info.plist` to source directory
+5. **Build**: Xcode uses the generated `Info.plist` for app bundle creation
+6. **Cleanup**: Generated file is removed after clean operation
+
+## Verification
+
+To test the implementation without a full build:
+
+```bash
+python3 scripts/verify_version_substitution.py
+```
+
+This script simulates the build process and verifies:
+- Version extraction from header file
+- Template processing
+- XML validity of generated Info.plist
+- Correct version substitution
+
+## Maintenance
+
+### Updating Version
+
+Version updates are made in `mods/src/version.h` only. The macOS launcher will automatically pick up changes during the next build.
+
+### Modifying Info.plist
+
+Changes to the Info.plist should be made to `Info.plist.template`, not the generated `Info.plist` file.
+
+### Troubleshooting
+
+If version substitution fails:
+
+1. Check that `mods/src/version.h` exists and contains expected `VERSION_*` definitions
+2. Verify `Info.plist.template` contains `${VERSION}` placeholders
+3. Run the verification script to identify specific issues
+4. Check xmake build output for error messages
+
+### File Patterns
+
+- `Info.plist.template` - **COMMIT** to git
+- `Info.plist` - **DO NOT COMMIT** (generated file, in .gitignore)

--- a/macos-launcher/src/Info.plist.template
+++ b/macos-launcher/src/Info.plist.template
@@ -10,31 +10,23 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-
 	<key>CFBundleName</key>
 	<string>STFC Patch</string>
 	<key>CFBundleDisplayName</key>
 	<string>Star Trek Fleet Command Community Patch</string>
 	<key>CFBundlePackageType</key>
-	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>12.0</string>
-
-    <key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>${VERSION}</string>
+	<key>CFBundleVersion</key>
+	<string>${VERSION}</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>
 	</array>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-    <key>CFBundleIconFile</key>
-    <string>launcher</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0</string>
+	<key>CFBundleIconFile</key>
+	<string>launcher</string>
 </dict>
 </plist>

--- a/macos-launcher/xmake.lua
+++ b/macos-launcher/xmake.lua
@@ -1,15 +1,29 @@
 add_rules("mode.debug", "mode.release")
 
+-- Function to extract version from version.h
+function get_version_from_header()
+    local version_file = path.join(os.scriptdir(), "../mods/src/version.h")
+    if not os.isfile(version_file) then
+        return "1.0.0.0"
+    end
+    
+    local content = io.readfile(version_file)
+    local major = content:match("#define VERSION_MAJOR%s+(%d+)")
+    local minor = content:match("#define VERSION_MINOR%s+(%d+)")
+    local revision = content:match("#define VERSION_REVISION%s+(%d+)")
+    local patch = content:match("#define VERSION_PATCH%s+(%d+)")
+    
+    if major and minor and revision and patch then
+        return major .. "." .. minor .. "." .. revision .. "." .. patch
+    end
+    return "1.0.0.0"
+end
+
 target("macOSLauncher")
 do
     add_rules("xcode.application")
     add_files("src/**/*.swift")
     add_files("src/*.swift", "src/*.xcassets")
-    add_files("src/Info.plist")
-    add_files("deps/PlzmaSDK/swift/*.swift")
-    add_files("deps/PlzmaSDK/src/*.cpp")
-    add_files("deps/PlzmaSDK/src/**/*.c")
-    add_files("deps/PlzmaSDK/src/**/*.cpp")
     add_files("src/*.cc")
     add_packages("7z", "lzma", "librsync")
     add_ldflags("-lc++")
@@ -17,4 +31,41 @@ do
     add_scflags("-Xcc -fmodules", "-Xcc -fmodule-map-file=macos-launcher/src/module.modulemap", "-D SWIFT_PACKAGE",
         { force = true })
     add_values("xcode.bundle_display_name", "Star Trek Fleet Command Community Patch")
+    
+    add_files("deps/PlzmaSDK/swift/*.swift")
+    add_files("deps/PlzmaSDK/src/*.cpp")
+    add_files("deps/PlzmaSDK/src/**/*.c")
+    add_files("deps/PlzmaSDK/src/**/*.cpp")
+    
+    -- Generate Info.plist from template during configuration
+    on_config(function (target)
+        local version = get_version_from_header()
+        local info_plist_template = path.join(os.scriptdir(), "src/Info.plist.template")
+        local info_plist_output = path.join(os.scriptdir(), "src/Info.plist")
+        
+        if os.isfile(info_plist_template) then
+            -- Read the template
+            local content = io.readfile(info_plist_template)
+            -- Replace ${VERSION} placeholder with actual version
+            content = content:gsub("${VERSION}", version)
+            
+            -- Write the processed Info.plist
+            io.writefile(info_plist_output, content)
+            print("Generated Info.plist with version: " .. version)
+        else
+            print("Warning: Info.plist.template not found at " .. info_plist_template)
+        end
+    end)
+    
+    -- Add the generated Info.plist file
+    add_files("src/Info.plist")
+    
+    -- Clean up generated file after build (optional)
+    after_clean(function (target)
+        local info_plist_output = path.join(os.scriptdir(), "src/Info.plist")
+        if os.isfile(info_plist_output) then
+            os.rm(info_plist_output)
+            print("Cleaned generated Info.plist")
+        end
+    end)
 end

--- a/scripts/verify_version_substitution.py
+++ b/scripts/verify_version_substitution.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Verification script for Info.plist version substitution implementation.
+This script simulates the xmake build process and verifies that version
+substitution works correctly.
+"""
+
+import os
+import sys
+import re
+import xml.etree.ElementTree as ET
+
+def get_version_from_header():
+    """Extract version from version.h (mimics the Lua function in xmake.lua)"""
+    version_file = "mods/src/version.h"
+    
+    if not os.path.isfile(version_file):
+        return "1.0.0.0"
+    
+    with open(version_file, 'r') as f:
+        content = f.read()
+    
+    major = re.search(r'#define VERSION_MAJOR\s+(\d+)', content)
+    minor = re.search(r'#define VERSION_MINOR\s+(\d+)', content)
+    revision = re.search(r'#define VERSION_REVISION\s+(\d+)', content)
+    patch = re.search(r'#define VERSION_PATCH\s+(\d+)', content)
+    
+    if all([major, minor, revision, patch]):
+        return f"{major.group(1)}.{minor.group(1)}.{revision.group(1)}.{patch.group(1)}"
+    
+    return "1.0.0.0"
+
+def simulate_build_process():
+    """Simulate the xmake on_config process"""
+    print("=== Simulating xmake build process ===")
+    
+    # Step 1: Extract version from version.h
+    version = get_version_from_header()
+    print(f"1. Extracted version: {version}")
+    
+    # Step 2: Check template file exists
+    template_file = "macos-launcher/src/Info.plist.template"
+    if not os.path.isfile(template_file):
+        print(f"❌ ERROR: Template file not found: {template_file}")
+        return False
+    
+    print(f"2. Found template file: {template_file}")
+    
+    # Step 3: Process template
+    with open(template_file, 'r') as f:
+        template_content = f.read()
+    
+    placeholders = template_content.count("${VERSION}")
+    print(f"3. Found {placeholders} version placeholders in template")
+    
+    processed_content = template_content.replace("${VERSION}", version)
+    
+    # Step 4: Write generated file
+    output_file = "macos-launcher/src/Info.plist"
+    with open(output_file, 'w') as f:
+        f.write(processed_content)
+    
+    print(f"4. Generated Info.plist with version {version}")
+    
+    # Step 5: Verify result
+    remaining = processed_content.count("${VERSION}")
+    if remaining > 0:
+        print(f"❌ ERROR: {remaining} placeholders remain unsubstituted")
+        return False
+    
+    # Step 6: Validate XML
+    try:
+        tree = ET.parse(output_file)
+        print("5. ✅ Generated Info.plist is valid XML")
+    except ET.ParseError as e:
+        print(f"❌ ERROR: Invalid XML: {e}")
+        return False
+    
+    # Step 7: Verify version in final output
+    root = tree.getroot()
+    dict_elem = root.find('dict')
+    
+    keys = []
+    values = []
+    for child in dict_elem:
+        if child.tag == 'key':
+            keys.append(child.text)
+        elif child.tag == 'string':
+            values.append(child.text)
+    
+    key_value_pairs = dict(zip(keys, values))
+    
+    version_fields = ['CFBundleShortVersionString', 'CFBundleVersion']
+    for field in version_fields:
+        if field in key_value_pairs:
+            if key_value_pairs[field] == version:
+                print(f"6. ✅ {field}: {key_value_pairs[field]}")
+            else:
+                print(f"❌ ERROR: {field} has wrong value: {key_value_pairs[field]} (expected {version})")
+                return False
+        else:
+            print(f"❌ ERROR: {field} not found in Info.plist")
+            return False
+    
+    print("✅ SUCCESS: All checks passed!")
+    return True
+
+def cleanup():
+    """Clean up generated files"""
+    output_file = "macos-launcher/src/Info.plist"
+    if os.path.isfile(output_file):
+        os.remove(output_file)
+        print(f"Cleaned up generated file: {output_file}")
+
+def main():
+    """Main function"""
+    print("Info.plist Version Substitution Verification")
+    print("=" * 50)
+    
+    # Change to repository root if not already there
+    if os.path.basename(os.getcwd()) != "stfc-mod":
+        # Try to find the repository root
+        for parent in ['.', '..', '../..']:
+            if os.path.isfile(os.path.join(parent, 'xmake.lua')) and os.path.isdir(os.path.join(parent, 'mods')):
+                os.chdir(parent)
+                break
+        else:
+            print("❌ ERROR: Cannot find repository root. Please run from stfc-mod directory.")
+            return False
+    
+    print(f"Working directory: {os.getcwd()}")
+    
+    try:
+        success = simulate_build_process()
+        return success
+    finally:
+        cleanup()
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
This relates to issue #80

I had the Github Copilot agent have a go at generating the Info.plist for MacOS by pulling the mod version number from `version.h` as appears to be done for the Windows build.

I have not written a single line of code myself and not tested this at all, so please treat with appropriate caution.