### PR TITLE
Improve CI performance for Windows builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,15 +34,17 @@ jobs:
   build-win:
     runs-on: windows-2025-vs2026
     env:
-      SCCACHE_DIR: ${{ github.workspace }}/build/.protobuf-sccache
-      SCCACHE_CACHE_SIZE: "1G"
+      STFC_MSVC_SCCACHE: "1"
+      WINDOWS_SCCACHE_SCHEMA: "v1"
+      SCCACHE_DIR: ${{ github.workspace }}/build/.windows-sccache
+      SCCACHE_CACHE_SIZE: "2G"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          submodules: "recursive"
+          submodules: false
           show-progress: false
 
       - name: Stamp commit hash
@@ -60,7 +62,7 @@ jobs:
         with:
           xmake-version: ${{ env.XMAKE_VERSION }}
 
-      - name: Setup protobuf sccache
+      - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.11
         with:
           version: ${{ env.PROTOBUF_SCCACHE_VERSION }}
@@ -72,10 +74,10 @@ jobs:
           if (-not $env:ImageVersion) { throw "GitHub runner ImageVersion is unavailable" }
           "image_version=$env:ImageVersion" >> $env:GITHUB_OUTPUT
 
-      - name: Set protobuf compiler cache identity
+      - name: Set Windows compiler cache identity
         shell: pwsh
         run: |
-          "SCCACHE_C_CUSTOM_CACHE_BUSTER=stfc-protobuf-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-xmake-${{ env.XMAKE_VERSION }}-windows-x64-release-${{ hashFiles('mods/src/prime/proto/*.proto', 'mods/xmake.lua', 'xmake.lua', 'xmake-requires.lock', 'xmake/dependencies/common.lua', 'xmake/dependencies/windows.lua', 'xmake/rules/protobuf_sccache.lua') }}" >> $env:GITHUB_ENV
+          "SCCACHE_C_CUSTOM_CACHE_BUSTER=stfc-windows-${{ env.WINDOWS_SCCACHE_SCHEMA }}-xmake-${{ env.XMAKE_VERSION }}-${{ steps.windows_toolchain.outputs.image_version }}" >> $env:GITHUB_ENV
 
       - name: Locate XMake caches
         id: xmake_cache_paths
@@ -104,15 +106,15 @@ jobs:
           path: build/.packages
           key: windows-x64-release-xmake-local-${{ env.XMAKE_VERSION }}-${{ env.XMAKE_CACHE_SCHEMA }}-${{ hashFiles('xmake/dependencies/common.lua', 'xmake/dependencies/windows.lua', 'xmake-requires.lock', 'xmake-packages/packages/s/spud/**') }}
 
-      - name: Restore protobuf compiler cache
-        id: restore_protobuf_sccache
+      - name: Restore Windows compiler cache
+        id: restore_windows_sccache
         uses: actions/cache/restore@v6
         with:
-          path: build/.protobuf-sccache
-          key: windows-x64-release-protobuf-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-${{ steps.windows_toolchain.outputs.image_version }}-${{ github.sha }}
+          path: build/.windows-sccache
+          key: windows-x64-release-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.WINDOWS_SCCACHE_SCHEMA }}-${{ steps.windows_toolchain.outputs.image_version }}-${{ github.sha }}
           restore-keys: |
-            windows-x64-release-protobuf-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-${{ steps.windows_toolchain.outputs.image_version }}-
-            windows-x64-release-protobuf-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.PROTOBUF_SCCACHE_SCHEMA }}-
+            windows-x64-release-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.WINDOWS_SCCACHE_SCHEMA }}-${{ steps.windows_toolchain.outputs.image_version }}-
+            windows-x64-release-sccache-${{ env.PROTOBUF_SCCACHE_VERSION }}-${{ env.WINDOWS_SCCACHE_SCHEMA }}-
 
       - name: Configure
         id: configure_windows
@@ -152,14 +154,14 @@ jobs:
           include-hidden-files: true
           retention-days: 3
 
-      - name: Reset protobuf compiler cache stats
+      - name: Reset compiler cache stats
         shell: pwsh
         run: sccache --zero-stats
 
       - name: Build
         run: xmake build -y stfc-community-mod
 
-      - name: Report protobuf compiler cache
+      - name: Report compiler cache
         shell: pwsh
         run: sccache --show-stats
 
@@ -192,12 +194,12 @@ jobs:
           path: build/.packages
           key: ${{ steps.restore_local_packages.outputs.cache-primary-key }}
 
-      - name: Save protobuf compiler cache
-        if: ${{ success() && !cancelled() && steps.restore_protobuf_sccache.outputs.cache-hit != 'true' }}
+      - name: Save Windows compiler cache
+        if: ${{ success() && !cancelled() && steps.restore_windows_sccache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v6
         with:
-          path: build/.protobuf-sccache
-          key: ${{ steps.restore_protobuf_sccache.outputs.cache-primary-key }}
+          path: build/.windows-sccache
+          key: ${{ steps.restore_windows_sccache.outputs.cache-primary-key }}
 
       - name: Save XMake
         if: ${{ success() && !cancelled() && steps.restore_xmake.outputs.cache-hit != 'true' }}

--- a/mods/xmake.lua
+++ b/mods/xmake.lua
@@ -78,7 +78,12 @@ do
         )
     end)
 
-        -- C++ sources
+    -- C++ sources
+    -- Override only the cxx file rule on Windows CI. This leaves protobuf's
+    -- separate .proto rule and generated-object build path untouched.
+    if is_plat("windows") and os.getenv("STFC_MSVC_SCCACHE") == "1" then
+        add_rules("stfc.cxx.sccache", {override = true})
+    end
     add_files("src/**.cc")
     add_headerfiles("src/**.h")
     add_includedirs("src", { public = true })

--- a/xmake.lua
+++ b/xmake.lua
@@ -22,4 +22,5 @@ add_rules("mode.release")
 add_rules("mode.releasedbg")
 
 includes("xmake/rules/protobuf_sccache.lua")
+includes("xmake/rules/cxx_sccache.lua")
 includes("mods")

--- a/xmake/rules/cxx_sccache.lua
+++ b/xmake/rules/cxx_sccache.lua
@@ -1,0 +1,47 @@
+-- Windows CI experiment for ordinary C++ compilation.
+--
+-- Replace only XMake's cxx file-build rule for targets that opt in. This keeps
+-- independent custom rules (notably protobuf generation/compilation) intact.
+rule("stfc.cxx.sccache")
+    add_deps("c++")
+    set_sourcekinds("cxx")
+
+    on_buildcmd_file(function(target, batchcmds, sourcefile, opt)
+        local compiler = import("core.tool.compiler")
+        local find_tool = import("lib.detect.find_tool")
+
+        local objectfile = target:objectfile(sourcefile)
+        local compiler_inst = compiler.load("cxx", {target = target})
+        local compiler_program, compiler_argv = compiler_inst:compargv(
+            sourcefile,
+            path(objectfile),
+            {
+                target = target,
+                configs = opt.configs,
+                rawargs = true
+            })
+
+        local sccache = target:data("stfc.windows.sccache")
+        if not sccache then
+            sccache = os.getenv("SCCACHE_PATH")
+            if not sccache or sccache == "" then
+                local tool = find_tool("sccache", {norun = true})
+                sccache = tool and tool.program or nil
+            end
+            sccache = assert(sccache,
+                "STFC_MSVC_SCCACHE=1 but sccache was not found")
+            target:data_set("stfc.windows.sccache", sccache)
+        end
+
+        local sccache_args = {compiler_program}
+        table.join2(sccache_args, compiler_argv)
+
+        batchcmds:mkdir(path.directory(objectfile))
+        batchcmds:show_progress(opt.progress,
+            "${color.build.object}sccache compiling.$(mode) %s", sourcefile)
+        batchcmds:vrunv(sccache, sccache_args, {envs = compiler_inst:runenvs()})
+
+        batchcmds:add_depfiles(sourcefile)
+        batchcmds:set_depcache(target:dependfile(objectfile))
+        batchcmds:set_depmtime(os.mtime(objectfile))
+    end)


### PR DESCRIPTION
This pull request updates the Windows CI build to use `sccache` for general C++ compilation, rather than only for protobuf. The changes include workflow updates, new XMake rules, and configuration tweaks to selectively enable `sccache` for C++ files on Windows CI, while keeping protobuf handling separate.

**CI workflow and caching improvements:**

* Updated `.github/workflows/ci.yaml` to generalize cache naming and environment variables from protobuf-specific to Windows-wide C++ compilation, increased cache size, and improved cache keying to include the toolchain image version. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL37-R47) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL63-R65) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL75-R80) [[4]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL107-R117) [[5]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL155-R164) [[6]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL195-R202)

**Build system enhancements:**

* Added a new XMake rule `stfc.cxx.sccache` in `xmake/rules/cxx_sccache.lua` to wrap ordinary C++ compilation with `sccache`, leaving protobuf compilation untouched.
* Modified `mods/xmake.lua` to conditionally apply the new `stfc.cxx.sccache` rule for C++ files when running on Windows CI with the appropriate environment variable set.
* Included the new rule in the main build script via `xmake.lua`.