### PR TITLE
fixes for local builds of universal dmg on macos

### DIFF
--- a/scripts/create-mac-dmg.sh
+++ b/scripts/create-mac-dmg.sh
@@ -38,6 +38,7 @@ test -f "build/macosx/$ARCH/$CONFIG/STFC Community Mod.app/Contents/Resources/As
 codesign --force --verify --verbose --deep --sign "-" build/macosx/$ARCH/$CONFIG/STFC\ Community\ Mod.app
 
 DMG_SOURCE="build/macosx/$ARCH/$CONFIG/dmg-source"
+rm -rf "$DMG_SOURCE"
 mkdir "$DMG_SOURCE"
 mv "build/macosx/$ARCH/$CONFIG/STFC Community Mod.app" "$DMG_SOURCE/"
 

--- a/xmake-packages/packages/o/openssl3/configure/patch.lua
+++ b/xmake-packages/packages/o/openssl3/configure/patch.lua
@@ -1,0 +1,25 @@
+function _add_ohos_targets(package)
+    if package:is_plat("harmony") then
+        io.gsub("Configurations/10-main.conf",
+            [=[("linux%-x86_64"%s-=>%s-{.-},)]=],
+            [=[%1
+
+    "ohos-aarch64" => {
+        inherit_from     => [ "linux-aarch64" ],
+        shared_extension => ".so"
+    },
+    "ohos-arm" => {
+        inherit_from     => [ "linux-armv4" ],
+        ex_libs          => add("-lclang_rt.builtins"),
+        shared_extension => ".so"
+    },
+    "ohos-x86_64" => {
+        inherit_from     => [ "linux-x86_64" ],
+        shared_extension => ".so"
+    },]=])
+    end
+end
+
+function main(package)
+    _add_ohos_targets(package)
+end

--- a/xmake-packages/packages/o/openssl3/fetch.lua
+++ b/xmake-packages/packages/o/openssl3/fetch.lua
@@ -1,0 +1,72 @@
+import("lib.detect.find_path")
+import("lib.detect.find_file")
+import("lib.detect.find_library")
+import("core.base.semver")
+
+-- http://www.slproweb.com/products/Win32OpenSSL.html
+function _find_package_on_windows(package, opt)
+    local bits = package:is_plat("x86") and "32" or "64"
+    local paths = {"$(reg HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\OpenSSL %(" .. bits .. "-bit%)_is1;Inno Setup: App Path)",
+                    "$(env PROGRAMFILES)/OpenSSL",
+                    "$(env PROGRAMFILES)/OpenSSL-Win" .. bits,
+                    "C:/OpenSSL",
+                    "C:/OpenSSL-Win" .. bits}
+
+    local result = {links = {}, linkdirs = {}}
+    local suffix = package:config("shared") and "" or "_static"
+    for _, name in ipairs({"libssl" .. suffix, "libcrypto" .. suffix, "libssl", "libcrypto"}) do
+        local linkinfo = find_library(name, paths, {suffixes = "lib"})
+        if linkinfo then
+            table.insert(result.links, linkinfo.link)
+            table.insert(result.linkdirs, linkinfo.linkdir)
+        end
+    end
+    if #result.links == 0 then
+        -- find light package
+        local arch = package:arch()
+        for _, name in ipairs({"libssl-3-" .. arch, "libcrypto-3-" .. arch}) do
+            local linkinfo = find_library(name, paths, {suffixes = "lib"})
+            if linkinfo then
+                table.insert(result.links, linkinfo.link)
+                table.insert(result.linkdirs, linkinfo.linkdir)
+            end
+        end
+    end
+    if #result.links ~= 2 then
+        return
+    end
+    if result.linkdirs then
+        result.linkdirs = table.unique(result.linkdirs)
+    end
+    local includedir = find_path(path.translate("openssl/ssl.h"), paths, {suffixes = "include"})
+    if includedir then
+        result.includedirs = result.includedirs or {}
+        table.insert(result.includedirs, includedir)
+    end
+    local openssl = find_file("openssl.exe", paths, {suffixes = "bin"})
+    if openssl then
+        result.bindirs = path.directory(openssl)
+        package:addenv("PATH", result.bindirs)
+        local version = try {function () return os.iorunv(openssl, {"version"}) end}
+        if version then
+            version = semver.match(version)
+            if version then
+                result.version = version:rawstr()
+            end
+        end
+    end
+    return result
+end
+
+function main(package, opt)
+    if opt.system and package.find_package then
+        local result
+        if package:is_plat("windows", "mingw", "msys") and is_host("windows") then
+            result = _find_package_on_windows(package, opt)
+        else
+            result = package:find_package("openssl", opt)
+        end
+        return result or false
+    end
+end
+

--- a/xmake-packages/packages/o/openssl3/patches/3.3.2/command-line-length.patch
+++ b/xmake-packages/packages/o/openssl3/patches/3.3.2/command-line-length.patch
@@ -1,0 +1,14 @@
+diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
+index 8ddb128..52b9ad6 100644
+--- a/Configurations/unix-Makefile.tmpl
++++ b/Configurations/unix-Makefile.tmpl
+@@ -1961,7 +1961,7 @@ EOF
+       my @objs = map { platform->obj($_) } @{$args{objs}};
+       my $deps = join(" \\\n" . ' ' x (length($lib) + 2),
+                       fill_lines(' ', $COLUMNS - length($lib) - 2, @objs));
+-      my $max_per_call = 500;
++      my $max_per_call = ($^O eq 'msys') ? 80 : 500;
+       my @objs_grouped;
+       push @objs_grouped, join(" ", splice @objs, 0, $max_per_call) while @objs;
+       my $fill_lib =
+ 

--- a/xmake-packages/packages/o/openssl3/patches/3.6.0/c20d4704e9e99a89d29f5ee848f9498694388905.patch
+++ b/xmake-packages/packages/o/openssl3/patches/3.6.0/c20d4704e9e99a89d29f5ee848f9498694388905.patch
@@ -1,0 +1,20 @@
+diff --git a/providers/implementations/ciphers/cipher_aes_cfb_hw_aesni.inc b/providers/implementations/ciphers/cipher_aes_cfb_hw_aesni.inc
+index d5577d00f132e..eb8e0164ac9ed 100644
+--- a/providers/implementations/ciphers/cipher_aes_cfb_hw_aesni.inc
++++ b/providers/implementations/ciphers/cipher_aes_cfb_hw_aesni.inc
+@@ -30,6 +30,7 @@
+ static int ossl_aes_cfb8_vaes_eligible(void) { return 0; }
+ static int ossl_aes_cfb1_vaes_eligible(void) { return 0; }
+ 
++#if (defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64))
+ /* active in 64-bit builds when AES-NI, AVX512F, and VAES are detected */
+ static int aes_cfb128_vaes_encdec_wrapper(
+     PROV_CIPHER_CTX* dat,
+@@ -56,6 +57,7 @@ static int aes_cfb128_vaes_encdec_wrapper(
+ 
+     return 1;
+ }
++#endif
+  
+ /* generates AES round keys for AES-NI and VAES implementations */
+ static int cipher_hw_aesni_initkey(PROV_CIPHER_CTX *dat,

--- a/xmake-packages/packages/o/openssl3/patches/3.6.1/pr29826.patch
+++ b/xmake-packages/packages/o/openssl3/patches/3.6.1/pr29826.patch
@@ -1,0 +1,17 @@
+diff --git a/ssl/quic/quic_reactor.c b/ssl/quic/quic_reactor.c
+index a754f285bbe2b..deec428152c58 100644
+--- a/ssl/quic/quic_reactor.c
++++ b/ssl/quic/quic_reactor.c
+@@ -76,6 +76,12 @@ void ossl_quic_reactor_cleanup(QUIC_REACTOR *rtor)
+ }
+ 
+ #if defined(OPENSSL_SYS_WINDOWS)
++
++/* Work around for MinGW builds. */
++#if defined(__MINGW32__) && !defined(SIO_UDP_NETRESET)
++#define SIO_UDP_NETRESET _WSAIOW(IOC_VENDOR, 15)
++#endif
++
+ /*
+  * On Windows recvfrom() may return WSAECONNRESET when destination port
+  * used in preceding call to sendto() is no longer reachable. The reset

--- a/xmake-packages/packages/o/openssl3/xmake.lua
+++ b/xmake-packages/packages/o/openssl3/xmake.lua
@@ -1,0 +1,324 @@
+package("openssl3")
+    set_homepage("https://www.openssl.org/")
+    set_description("A robust, commercial-grade, and full-featured toolkit for TLS and SSL.")
+    set_license("Apache-2.0")
+
+    add_urls("https://github.com/openssl/openssl/archive/refs/tags/openssl-$(version).zip")
+
+    add_versions("3.6.3", "e24124cb19d26f2045f53d3ee94871288136242931d001c71646c2403cfedee3")
+    add_versions("3.6.2", "599a1053292f6aec83da0f98ecd48c587fdb3184f6d18a25ecc9a9ffbc024bb4")
+    add_versions("3.6.1", "b5fb172237ed3b1b47a9f7f15d3a40f9e9563f59f544b7078780ee27279a3c0f")
+    add_versions("3.6.0", "273d989d1157f0bd494054e1b799b6bdba39d4acaff6dfcb8db02656f1b454dd")
+    add_versions("3.5.7", "aefd8a46c45e05858cc32c97ee5c8e6966254b7fd972051aa582e0a4bbe3b5c1")
+    add_versions("3.5.6", "6a21a7ee475ff4fd25dc020045d3c9eb14729056ee207885e4cfa959bf449e27")
+    add_versions("3.5.5", "00d0b9dbe230bf7adac34e6da4557ca8874bf1411547f7e13d86bdb4342c04f8")
+    add_versions("3.5.4", "6e6ca87952a3908282bae88c6e6a5d38bc6fc25d5570218866e5f2d206c03be1")
+    add_versions("3.5.1", "9a1472b5e2a019f69da7527f381b873e3287348f3ad91783f83fff4e091ea4a8")
+    add_versions("3.4.6", "508db124a24203a6ba755aa95f68b206145e3aa6846f9c44e6f2ee1faca66be6")
+    add_versions("3.4.5", "be09c6aa135d39620bce7a89f11630e31699a65d2939226b644600b736eb4a63")
+    add_versions("3.4.4", "df15282cfd91ff525bebe91783e7a1912cdd6303627a6ca7caf50ce449bc85bb")
+    add_versions("3.4.2", "d313ac2ee07ad0d9c6e9203c56a485b3ecacac61c18fe450fe3c1d4db540ad71")
+    add_versions("3.3.7", "9daf79eef0b94d3dd3cb49968ec777c42151ef9ce067632af5d820369fb3b176")
+    add_versions("3.3.6", "9b604f79c0e7311ac97904d603d13c84425c35bfd83d73f9037c9cbf99bb262b")
+    add_versions("3.3.4", "88c892a670df8924889f3bfd2f2dde822e1573a23dc4176556cb5170b40693ea")
+    add_versions("3.3.2", "4cda357946f9dd5541b565dba35348d614288e88aeb499045018970c789c9d61")
+    add_versions("3.3.1", "307284f39bfb7061229c57e263e707655aa80aa9950bf6def28ed63fec91a726")
+    add_versions("3.2.6", "8d65844c317bf9c95420bc625d54cff40a82b5a7b0d0b15abb8a74ab299431a9")
+    add_versions("3.2.5", "08a3fe150bd69a83ac64e222bdccf0698c493a94e161e4d080c82d1f308dc4e1")
+    add_versions("3.1.8", "bbd5cbd8cc8ea852d31c001a9b767eadef0548b098e132b580a1f0c80d1778b7")
+    add_versions("3.0.21", "df3842f650bab371489eb67d8b04fdf4ef659573ec03c069326af034a82105a5")
+    add_versions("3.0.20", "5cc5b6e497cfa75ef61e8c4783212c3c374a47a144844c1c70fb0634127008aa")
+    add_versions("3.0.19", "82ff998847ee1346fefa7b6aa9402fbd0c81e971ad88793e44b21a39f2be1790")
+    add_versions("3.0.17", "1129500758754ce4ff7eba7e46403dd56d5aa0a4e517a8fff7dac6fe120d0461")
+    add_versions("3.0.14", "9590b9ae18c4de183be74dfc9da5be1f1e8f85dd631a78bc74c0ebc3d7e27a93")
+    add_versions("3.0.7", "fcb37203c6bf7376cfd3aeb0be057937b7611e998b6c0d664abde928c8af3eb7")
+    add_versions("3.0.6", "9b45be41df0d6e9cf9e340a64525177662f22808ac69aee6bfb29c511284dae4")
+    add_versions("3.0.5", "4313c91fb0412e6a600493eb7c59bd555c4ff2ea7caa247a98c8456ad6f9fc74")
+    add_versions("3.0.4", "5b690a5c00e639f3817e2ee15c23c36874a1f91fa8c3a83bda3276d3d6345b76")
+    add_versions("3.0.3", "9bc56fd035f980cf74605264b04d84497df657c4f7ca68bfa77512e745f6c1a6")
+    add_versions("3.0.2", "ce3cbb41411731852e52bf96c06f097405c81ebf60ba81e0b9ca05d41dc92681")
+    add_versions("3.0.1", "53d8121af1c33c62a05a5370e9ba40fcc237717b79a7d99009b0c00c79bd7d78")
+    add_versions("3.0.0", "1bdb33f131af75330de94475563c62d6908ac1c18586f7f4aa209b96b0bfc2f9")
+
+    -- https://github.com/microsoft/vcpkg/blob/11faa3f168ec2a2f77510b92a42fb5c8a7e28bd8/ports/openssl/command-line-length.patch
+    add_patches("3.3.2", path.join(os.scriptdir(), "patches", "3.3.2", "command-line-length.patch"), "e969153046f22d6abbdedce19191361f20edf3814b3ee47fb79a306967e03d81")
+    -- https://github.com/openssl/openssl/issues/28745
+    add_patches("3.6.0", path.join(os.scriptdir(), "patches", "3.6.0", "c20d4704e9e99a89d29f5ee848f9498694388905.patch"), "5d2523a6e0cc938c5d5acab849899da4b6a333b51151eaac5bd3b52741536bbc")
+    add_patches("3.5.5", path.join(os.scriptdir(), "patches", "3.6.1", "pr29826.patch"), "395cade297b377130df1c8fe17cae94ff2b3d82ea1dc7fbac8acfeb597fa8b8b")
+    add_patches("3.6.1", path.join(os.scriptdir(), "patches", "3.6.1", "pr29826.patch"), "395cade297b377130df1c8fe17cae94ff2b3d82ea1dc7fbac8acfeb597fa8b8b")
+
+    on_fetch("fetch")
+
+    -- https://security.stackexchange.com/questions/173425/how-do-i-calculate-md2-hash-with-openssl
+    add_configs("md2", {description = "Enable MD2 on OpenSSl3 or not", default = false, type = "boolean"})
+    add_configs("multi-threading", {description = "Enable multi-threading support.", default = true, type = "boolean"})
+
+    if is_plat("wasm") then
+        add_configs("shared", {description = "Build shared library.", default = false, type = "boolean", readonly = true})
+    end
+
+    -- @see https://github.com/xmake-io/xmake-repo/pull/7797#issuecomment-3153471643
+    if is_plat("windows") then
+        add_configs("jom", {description = "Try using jom to compile in parallel.", default = true, type = "boolean"})
+    end
+
+    on_load(function (package)
+        if not package:is_precompiled() then
+            if package:is_plat("windows") then
+                package:add("deps", "nasm")
+                -- the perl executable found in GitForWindows will fail to build OpenSSL
+                -- see https://github.com/openssl/openssl/blob/master/NOTES-PERL.md#perl-on-windows
+                package:add("deps", "strawberry-perl", {system = false})
+                if package:config("jom") then
+                    -- check xmake tool jom
+                    import("package.tools.jom", {try = true})
+                    if jom then
+                        package:add("deps", "jom", {private = true})
+                    end
+                end
+            elseif package:is_plat("android", "wasm") and is_host("windows") and os.arch() == "x64" then
+                -- when building for android on windows, use msys2 perl instead of strawberry-perl to avoid configure issue
+                package:add("deps", "msys2", {configs = {msystem = "MINGW64", base_devel = true}, private = true})
+            end
+        end
+
+        -- @note we must use package:is_plat() instead of is_plat in description for supporting add_deps("openssl", {host = true}) in python
+        if package:is_plat("windows") then
+            package:add("links", "libssl", "libcrypto")
+        else
+            package:add("links", "ssl", "crypto")
+        end
+        if package:is_plat("windows", "mingw", "msys") then
+            package:add("syslinks", "ws2_32", "user32", "crypt32", "advapi32")
+        elseif package:is_plat("linux", "bsd", "cross") then
+            package:add("syslinks", "dl")
+            if (package:config("multi-threading")) then
+                package:add("syslinks", "pthread")
+            end
+        end
+        if package:is_plat("linux") then
+            package:add("extsources", "apt::libssl-dev")
+        end
+    end)
+
+    on_install("windows", function (package)
+        import("package.tools.jom", {try = true})
+        import("package.tools.nmake")
+        local configs = {"Configure", "no-tests"}
+        local target
+        if package:is_arch("x86", "i386") then
+            target = "VC-WIN32"
+        elseif package:is_arch("arm64") then
+            target = "VC-WIN64-ARM"
+        elseif package:is_arch("arm.*") then
+            target = "VC-WIN32-ARM"
+        else
+            target = "VC-WIN64A"
+        end
+        table.insert(configs, target)
+        table.insert(configs, package:config("shared") and "shared" or "no-shared")
+        table.insert(configs, "--prefix=" .. package:installdir())
+        table.insert(configs, "--openssldir=" .. package:installdir())
+
+        if package:config("md2") then
+            table.insert(configs, "enable-md2")
+        end
+        table.insert(configs, package:config("multi-threading") and "threads" or "no-threads")
+
+        if package:config("jom") and jom then
+            table.insert(configs, "no-makedepend")
+        end
+
+        if package:is_debug() then
+            table.insert(configs, "/FS")
+        else
+            io.replace("Configurations/10-main.conf", "/debug", "", {plain = true})
+            io.replace("Configurations/10-main.conf", "/Zi", "", {plain = true})
+            io.replace("Configurations/50-masm.conf", "/Zi", "", {plain = true})
+            if package:version():ge("3.1") then
+                io.replace("Configurations/50-win-clang-cl.conf", "/Zi", "", {plain = true})
+            end
+            io.replace("util/copy.pl", "if (-d $dest)", "if (! -e $_) { next; }\n\tif (-d $dest)", {plain = true})
+        end
+
+        os.vrunv("perl", configs)
+
+        if package:config("jom") and jom then
+            jom.build(package)
+            jom.make(package, {"install_sw"})
+        else
+            nmake.build(package)
+            nmake.make(package, {"install_sw"})
+        end
+    end)
+
+    on_install("mingw", "msys", function (package)
+        local configs = {"Configure", "--libdir=lib", "no-tests"}
+        table.insert(configs, package:is_arch("i386", "x86") and "mingw" or "mingw64")
+        table.insert(configs, package:config("shared") and "shared" or "no-shared")
+        local installdir = package:installdir()
+        -- Use MSYS2 paths instead of Windows paths
+        if is_subhost("msys") then
+            installdir = installdir:gsub("(%a):[/\\](.+)", "/%1/%2"):gsub("\\", "/")
+        end
+        table.insert(configs, "--prefix=" .. installdir)
+        table.insert(configs, "--openssldir=" .. installdir)
+
+        if package:config("md2") then
+            table.insert(configs, "enable-md2")
+        end
+        table.insert(configs, package:config("multi-threading") and "threads" or "no-threads")
+
+        local buildenvs = import("package.tools.autoconf").buildenvs(package)
+        buildenvs.RC = package:build_getenv("mrc")
+        if is_subhost("msys") then
+            local rc = buildenvs.RC
+            if rc then
+                rc = rc:gsub("(%a):[/\\](.+)", "/%1/%2"):gsub("\\", "/")
+                buildenvs.RC = rc
+            end
+        end
+        -- fix 'cp: directory fuzz does not exist'
+        if package:config("shared") then
+            os.mkdir("fuzz")
+        end
+        os.vrunv("perl", configs, {envs = buildenvs})
+        import("package.tools.make").build(package)
+        import("package.tools.make").make(package, {"install_sw"})
+    end)
+
+    on_install("macosx", "bsd", function (package)
+        -- https://wiki.openssl.org/index.php/Compilation_and_Installation#PREFIX_and_OPENSSLDIR
+        local buildenvs = import("package.tools.autoconf").buildenvs(package)
+
+        -- Pass an explicit Configure target. ./config autodetects the *host*
+        -- architecture, which breaks cross-arch builds on Apple Silicon
+        -- (e.g. `xmake f -a x86_64` on an arm64 machine configures
+        -- darwin64-arm64, generates ARMv8 assembly and then fails in
+        -- crypto/arm_arch.h with "unsupported ARM architecture").
+        local target
+        if package:is_plat("macosx") then
+            if package:is_arch("x86_64") then
+                target = "darwin64-x86_64-cc"
+            elseif package:is_arch("arm64") then
+                target = "darwin64-arm64-cc"
+            end
+        end
+
+        local configs = {"--openssldir=" .. package:installdir(),
+                         "--libdir=lib",
+                         "--prefix=" .. package:installdir()}
+        if target then
+            table.insert(configs, 1, target)
+        end
+        table.insert(configs, package:config("shared") and "shared" or "no-shared")
+        if package:debug() then
+            table.insert(configs, "--debug")
+        end
+
+        if package:config("md2") then
+            table.insert(configs, "enable-md2")
+        end
+        table.insert(configs, package:config("multi-threading") and "threads" or "no-threads")
+
+        -- xmake builds OpenSSL in-tree inside the shared source cache, so a
+        -- previous build for a different architecture leaves stale object
+        -- files and a stale configdata.pm behind. Clean before reconfiguring.
+        if os.isfile("configdata.pm") then
+            os.tryrunv("make", {"distclean"})
+        end
+        os.vrunv("./config", configs, {envs = buildenvs})
+        local makeconfigs = {CFLAGS = buildenvs.CFLAGS, ASFLAGS = buildenvs.ASFLAGS}
+        import("package.tools.make").build(package, makeconfigs)
+        import("package.tools.make").make(package, {"install_sw"})
+        if package:config("shared") then
+            os.tryrm(path.join(package:installdir("lib"), "*.a"))
+        end
+    end)
+
+    on_install("linux", "cross", "android", "iphoneos", "wasm", "harmony", function (package)
+        local target_arch = "generic32"
+        if package:is_arch("x86_64") then
+            target_arch = "x86_64"
+        elseif package:is_arch("i386", "x86") then
+            target_arch = "x86"
+        elseif package:is_arch("arm64", "arm64-v8a") then
+            target_arch = "aarch64"
+        elseif package:is_arch("arm.*") then
+            target_arch = "armv4"
+        elseif package:is_arch(".*64") then
+            target_arch = "generic64"
+        end
+
+        local target_plat = "linux"
+        if package:is_plat("macosx") then
+            target_plat = "darwin64"
+            target_arch = "x86_64-cc"
+        elseif package:is_plat("harmony") then
+            target_plat = "ohos"
+            if package:is_arch("arm64", "arm64-v8a") then
+                target_arch = "aarch64"
+            elseif package:is_arch("arm.*") then
+                target_arch = "arm"
+            end
+        elseif package:is_plat("iphoneos") then
+            local xcode = package:toolchain("xcode")
+            local simulator = xcode and xcode:config("appledev") == "simulator"
+            if simulator then
+                target_plat = "iossimulator"
+                target_arch = "xcrun"
+            else
+                if package:is_arch("arm64", "x86_64") then
+                    target_plat = "ios64"
+                else
+                    target_plat = "ios"
+                end
+                target_arch = "cross"
+            end
+        end
+
+        local target = target_plat .. "-" .. target_arch
+        local configs = {target,
+                         package:config("shared") and "shared" or "no-shared",
+                         "--libdir=lib",
+                         "--openssldir=" .. package:installdir():gsub("\\", "/"),
+                         "--prefix=" .. package:installdir():gsub("\\", "/")}
+
+        if package:config("md2") then
+            table.insert(configs, "enable-md2")
+        end
+        table.insert(configs, package:config("multi-threading") and "threads" or "no-threads")
+
+        if package:is_plat("wasm") then
+            -- @see https://github.com/openssl/openssl/issues/12174
+            table.insert(configs, "no-afalgeng")
+        end
+
+        import("configure.patch")(package)
+        local buildenvs = import("package.tools.autoconf").buildenvs(package)
+        if (package:is_plat("android") and is_host("windows")) or
+            package:is_plat("wasm") then
+
+            buildenvs.CFLAGS = buildenvs.CFLAGS:gsub("\\", "/")
+            buildenvs.CXXFLAGS = buildenvs.CXXFLAGS:gsub("\\", "/")
+            buildenvs.CPPFLAGS = buildenvs.CPPFLAGS:gsub("\\", "/")
+            buildenvs.ASFLAGS = buildenvs.ASFLAGS:gsub("\\", "/")
+            os.vrunv("perl", table.join("./Configure", configs), {envs = buildenvs})
+        else
+            os.vrunv("./Configure", configs, {envs = buildenvs})
+        end
+
+        if is_host("windows") and package:is_plat("wasm") then
+            io.replace("Makefile", "bat.exe", "bat", {plain = true})
+        end
+        local makeconfigs = {CFLAGS = buildenvs.CFLAGS, ASFLAGS = buildenvs.ASFLAGS}
+        import("package.tools.make").build(package, makeconfigs)
+        import("package.tools.make").make(package, {"install_sw"})
+        if package:config("shared") then
+            os.tryrm(path.join(package:installdir("lib"), "*.a"))
+        end
+    end)
+
+    on_test(function (package)
+        assert(package:has_cfuncs("SSL_new", {includes = "openssl/ssl.h"}))
+    end)


### PR DESCRIPTION
Two things:
1) the upstream xmake package def for openssl doesn't handle building on arm correctly
2) our build script doesn't clean up properly

This replicates the upstream patches and adds stuff to make openssl build on macOS-arm 