### PR TITLE
fix: drop duplicate [sync] token/url in English example config

### DIFF
--- a/.github/workflows/validate-example-configs.yaml
+++ b/.github/workflows/validate-example-configs.yaml
@@ -1,0 +1,24 @@
+name: Validate example configs
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-example-configs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate example TOML configs
+        run: python scripts/validate-example-configs.py

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -760,12 +760,6 @@ verify_ssl = true
 #
 #  <[========================================================================================]>
 
-# The token that is used to provide authentication
-token = ""
-
-# The url of the server to send data to
-url = ""
-
 [sync.targets.nextspocksclub]
 
 #  <[========================================================================================]>

--- a/scripts/validate-example-configs.py
+++ b/scripts/validate-example-configs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate that every bundled example config is well-formed TOML.
+
+The mod loads user configs with toml++, which -- per the TOML spec -- rejects
+duplicate keys and other malformed input outright (it does not silently ignore
+them). The example files exist to be copied into community_patch_settings.toml,
+so a malformed example is a copy-paste trap. This check parses each example and
+fails if any of them is not valid TOML, guarding against that at PR time.
+"""
+
+import glob
+import os
+import sys
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for older runners
+    import tomli as tomllib  # type: ignore
+
+
+def main() -> int:
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    pattern = os.path.join(root, "example_community_patch_settings*.toml")
+    files = sorted(glob.glob(pattern))
+    if not files:
+        print(f"no example config files matched {pattern!r}", file=sys.stderr)
+        return 1
+
+    failures = []
+    for path in files:
+        name = os.path.basename(path)
+        try:
+            with open(path, "rb") as handle:
+                tomllib.load(handle)
+        except tomllib.TOMLDecodeError as exc:
+            print(f"  FAIL  {name}: {exc}")
+            failures.append(name)
+        else:
+            print(f"  PASS  {name}")
+
+    if failures:
+        print(
+            f"\n{len(failures)} example config(s) are not valid TOML: "
+            + ", ".join(failures),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nall {len(files)} example config(s) are valid TOML")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

`example_community_patch_settings_en.toml` declares `token` and `url` twice under `[sync]`:

- once alongside `proxy` at the top of the `[sync]` table (correct), and
- again as an orphaned pair — with no `[sync.targets.*]` header above it — right after the "Sync Targets" ASCII banner.

Two keys of the same name in one TOML table is invalid TOML, so strict parsers reject the **entire file**:

```
$ python3 -c "import tomllib; tomllib.load(open('example_community_patch_settings_en.toml','rb'))"
tomllib.TOMLDecodeError: Cannot overwrite a value (at line 764, column 11)
```

toml++ (which the mod itself uses to load configs) rejects it the same way.

## Impact

Low in practice: the release artifacts ship `version.dll` only, so end users rarely encounter this file, and the game itself never parses the examples. But the committed example is still invalid TOML, and anyone who copies the **English** example from source into their `community_patch_settings.toml` gets a config that fails to load.

## Fix

Remove the orphaned `token`/`url` pair so `[sync]` declares them once. The banner now flows straight into `[sync.targets.nextspocksclub]`, matching the `de`/`fr`/`nl` examples — which were authored correctly and are unaffected.

Verified: the file parses cleanly after the change.

## Regression guard

The second commit adds `scripts/validate-example-configs.py` and a small `ubuntu-latest` workflow that parses every `example_community_patch_settings*.toml` and fails if any is not valid TOML. It's **red on the pre-fix `_en` and green after**, so a future malformed example can't land unnoticed — the C++ build never parses these files. The job is independent of the platform build matrix and needs no secrets.

## Scope

- English (`_en`) only; `_de` / `_fr` / `_nl` already correct.
- Example/docs only — no code, no behavior change.
- Present since the localized examples were added in #226.