### PR TITLE
fix: resolve base-raid station defenders in the battlelog names block

### DIFF
--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -700,6 +700,23 @@ namespace names
     }
   }
 
+  // Cracked stations have no fleet, so a base raid's defender isn't in deployed_fleets -- take the
+  // participant ids from the journal instead.
+  static inline void collect_journal_participants(const nlohmann::json&            journal,
+                                                  std::unordered_set<std::string>& user_ids)
+  {
+    for (const char* key : {"initiator_id", "target_id"}) {
+      if (!journal.contains(key) || journal[key].is_null()) {
+        continue;
+      }
+      const auto& id = journal[key].get<std::string>();
+      // NPC ids contain '_' (mar_61, npc_<id>_1); player ids don't -- skip, nothing to resolve.
+      if (!id.empty() && id.find('_') == std::string::npos) {
+        user_ids.insert(id);
+      }
+    }
+  }
+
   static inline void collect_alliance_ids(const nlohmann::json& names, std::unordered_set<int64_t>& alliance_ids)
   {
     for (const auto& [player_id, entry] : names.items()) {
@@ -964,6 +981,7 @@ static void ship_combat_log_data()
         std::unordered_set<std::string> user_ids;
         collect_user_ids_from_fleet(target_fleet_data, user_ids);
         collect_user_ids_from_fleet(initiator_fleet_data, user_ids);
+        collect_journal_participants(journal, user_ids);
 
         json profiles_request{{"user_ids", json::array()}};
         resolve_player_names(user_ids, names, profiles_request["user_ids"], now);


### PR DESCRIPTION
## Problem

`ship_combat_log_data()` builds the battlelog `names` block by collecting user ids and resolving them through `/user_profile/profiles`. Those ids come **only from fleet data**, via `collect_user_ids_from_fleet`, which walks `deployed_fleets[].uid`.

For a **base raid the target is a station, not a fleet**. The station owner only lands in `deployed_fleets` when the station happens to have ships docked or defending — in that case the existing collector picks the owner up and the defender resolves fine. When the station's fleet list is **empty**, the owner appears nowhere in fleet data, and because the journal's own `initiator_id` / `target_id` are never added to `user_ids`, the defender is never looked up. It arrives in the synced battlelog with `name == uid` and `alliance == ""` — unidentified.

Across a 76,323-journal corpus, **every** battlelog that arrived with an unresolved player participant was a base raid — 1,159 of 1,159 — while 63,785 hostile, 5,432 defense, 1,857 outpost, 1,590 PvP, 897 armada and 438 mission logs had none. In every case the missing id was `target_id`, never `initiator_id` (defense battles put a player in the target slot and resolve fine, so the defect is specifically "target is a station"). The dividing line is exactly whether `target_fleet_data.deployed_fleets` was empty: where it wasn't, the owner rode along in a fleet; where it was, the defender was lost.

(Caveat: that's a single alliance's corpus with ~8–10 syncing clients — strong evidence that nothing but empty-fleet base raids hits this path, though it can't rule out a rarer case none of us has flown. NPC-target battles are excluded by construction — there's no profile to resolve.)

## Fix

Add a small helper next to `collect_user_ids_from_fleet` that also takes ids from the journal itself, and call it once in `ship_combat_log_data()`:

```cpp
collect_user_ids_from_fleet(target_fleet_data, user_ids);
collect_user_ids_from_fleet(initiator_fleet_data, user_ids);
collect_journal_participants(journal, user_ids);   // <-- added
```

`collect_journal_participants` reads `initiator_id` / `target_id`. Player ids are a letter prefix + hex with **no underscore**; NPC ids are underscore-delimited (`mar_61`, `npc_<id>_1`, `dyn_npc_…`), so it skips underscore ids to avoid a wasted profile lookup on NPCs.

**No new endpoint** — the same `/user_profile/profiles` call already runs, and `resolve_player_names` de-dupes against the cache, so ids that also appear in the fleets cost nothing extra. The alliance-resolution step below picks up the new `alliance_id`s automatically.

## Verified

Raided the same base before and after the change and compared the synced payloads:

- **Before:** the `names` block contained only the attacker; the defender's id was absent.
- **After:** the `names` block includes the defender, resolved to their player name and alliance tag.

## Scope

- 19 lines, one file (`mods/src/patches/parts/sync.cc`), purely additive.
- No behavior change for non-base-raid battlelogs (fleet-vs-fleet already resolved both sides).
- Only affects **new** syncs — existing battlelogs carry their `names` from capture time and aren't retroactively changed.
