### PR TITLE
Extend tagged chest purchase sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This project is maintained solely at my own cost of time, energy and money. Any 
 - Disable galaxy chat
 - Enable/Disable hotkeys (community mod or scopely)
 - Enable extended donation slider (alliance)
+- Extend tagged chest-purchase sliders up to 160 on Windows
 - Show alternative cargo screens for:
   - default
   - player

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -615,6 +615,13 @@ extend_donation_max = 80
 # Erweiterung des Spendenschiebereglers aktivieren
 extend_donation_slider = true
 
+# Subgroup: Truhenkäufe
+# ---------------------
+
+# Maximum für markierte Truhenkauf-Schieberegler unter Windows (0 deaktiviert; Werte über 160 werden begrenzt).
+# Höhere native Grenzwerte bleiben erhalten.
+extend_chest_purchase_max = 160
+
 # Subgroup: HUD
 # -------------
 

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -615,6 +615,13 @@ extend_donation_max = 80
 # Extend donation slider enable
 extend_donation_slider = true
 
+# Subgroup: Chest Purchases
+# -------------------------
+
+# Maximum for tagged chest-purchase sliders on Windows (0 disables; values above 160 are clamped).
+# Native limits above this value are preserved.
+extend_chest_purchase_max = 160
+
 # Subgroup: HUD
 # -------------
 

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -615,6 +615,14 @@ extend_donation_max = 80
 # Activer l'extension du curseur de don
 extend_donation_slider = true
 
+# Subgroup: Achats de coffres
+# ---------------------------
+
+# Maximum des curseurs d'achat de coffre marqués sous Windows
+# (0 désactive ; les valeurs supérieures à 160 sont limitées).
+# Les limites natives supérieures sont conservées.
+extend_chest_purchase_max = 160
+
 # Subgroup: HUD
 # -------------
 

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -615,6 +615,13 @@ extend_donation_max = 80
 # Zet dit aan als je de schuifregelaar voor alliantie donaties wilt uitbreiden
 extend_donation_slider = true
 
+# Subgroup: Kistaankopen
+# ----------------------
+
+# Maximum voor gemarkeerde kistaankoop-schuifregelaars op Windows (0 schakelt uit; waarden boven 160 worden begrensd).
+# Hogere ingebouwde limieten blijven behouden.
+extend_chest_purchase_max = 160
+
 # Subgroup: HUD
 # -------------
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -872,6 +872,8 @@ void Config::Load()
                             DCU::auto_confirm_ft_upgrade, write_config);
 
 #if _WIN32
+  this->extend_chest_purchase_max = get_config_or_default(config, parsed, "ui", "extend_chest_purchase_max",
+                                                          DCU::extend_chest_purchase_max, write_config);
   this->extend_donation_slider =
       get_config_or_default(config, parsed, "ui", "extend_donation_slider", DCU::extend_donation_slider, write_config);
   this->extend_donation_max =

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -183,6 +183,7 @@ public:
   std::vector<int> disabled_banner_types;
   std::vector<int> notify_banner_types;
 
+  int  extend_chest_purchase_max;
   int  extend_donation_max;
   bool extend_donation_slider;
   bool disable_move_keys;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -225,6 +225,7 @@ namespace UI
   constexpr const char* hud_q_trials                = "auto";
   constexpr const char* auto_confirm_instant_warp   = "none";
   constexpr const char* notify_banner_types         = "";
+  constexpr auto        extend_chest_purchase_max   = 160;
   constexpr auto        extend_donation_max         = 80;
   constexpr bool        extend_donation_slider      = true;
   constexpr bool        show_armada_cargo           = true;

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -6,6 +6,9 @@
 #include <prime/Hub.h>
 #include <prime/IList.h>
 #include <prime/InventoryForPopup.h>
+#if _WIN32
+#include <prime/InventoryUseRowWidget.h>
+#endif
 #include <prime/ShopSummaryDirector.h>
 
 #include <il2cpp/il2cpp_helper.h>
@@ -19,6 +22,13 @@
 #include <algorithm>
 #include <prime/ActionQueueManager.h>
 #include <prime/InterstitialViewController.h>
+
+#if _WIN32
+namespace
+{
+constexpr int64_t kMaximumChestPurchaseMax = 160;
+}
+#endif
 
 void InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1, int64_t a2)
 {
@@ -38,6 +48,26 @@ void InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1, i
 
   original(a1, a2);
 }
+
+#if _WIN32
+// IsChestPurchase is populated too late for the existing MaxItemsToUse setter hook, so adjust the tagged context at
+// the row-render seam instead.
+void InventoryUseRowWidget_SetWidgetData(auto original, InventoryUseRowWidget* widget)
+{
+  if (widget) {
+    if (auto* context = widget->Context; context && context->IsChestPurchase) {
+      const auto native_max    = context->MaxItemsToUse;
+      const auto requested_max = static_cast<int64_t>(Config::Get().extend_chest_purchase_max);
+      const auto bounded_max   = std::min(requested_max, kMaximumChestPurchaseMax);
+      if (native_max > 0 && bounded_max > native_max) {
+        context->MaxItemsToUse = bounded_max;
+      }
+    }
+  }
+
+  original(widget);
+}
+#endif
 
 void BundleDataWidget_OnActionButtonPressedCallback(auto original, BundleDataWidget* _this)
 {
@@ -60,6 +90,20 @@ void InstallMiscPatches()
       ErrorMsg::MissingMethod("InventoryForPopup", "set_MaxItemsToUse");
     } else {
       SPUD_STATIC_DETOUR(ptr, InventoryForPopup_set_MaxItemsToUse);
+    }
+  }
+
+  if (Config::Get().extend_chest_purchase_max > 0) {
+    auto row_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Inventories", "InventoryUseRowWidget");
+    if (!row_widget.isValidHelper()) {
+      ErrorMsg::MissingHelper("Digit.Prime.Inventories", "InventoryUseRowWidget");
+    } else {
+      auto ptr = row_widget.GetMethod("SetWidgetData", 0);
+      if (!ptr) {
+        ErrorMsg::MissingMethod("InventoryUseRowWidget", "SetWidgetData");
+      } else {
+        SPUD_STATIC_DETOUR(ptr, InventoryUseRowWidget_SetWidgetData);
+      }
     }
   }
 #endif

--- a/mods/src/prime/InventoryForPopup.h
+++ b/mods/src/prime/InventoryForPopup.h
@@ -2,9 +2,13 @@
 
 #include <il2cpp/il2cpp_helper.h>
 
+#include <cstdint>
+
 struct InventoryForPopup {
 public:
-  __declspec(property(get = __get_IsDonationUse, put = __set_IsDonationUse)) bool IsDonationUse;
+  __declspec(property(get = __get_MaxItemsToUse, put = __set_MaxItemsToUse)) int64_t MaxItemsToUse;
+  __declspec(property(get = __get_IsDonationUse, put = __set_IsDonationUse)) bool    IsDonationUse;
+  __declspec(property(get = __get_IsChestPurchase)) bool                             IsChestPurchase;
 
 private:
   static IL2CppClassHelper& get_class_helper()
@@ -15,6 +19,19 @@ private:
   }
 
 public:
+  int64_t __get_MaxItemsToUse()
+  {
+    static auto property = get_class_helper().GetProperty("MaxItemsToUse");
+    const auto* value    = property.Get<int64_t>(this);
+    return value ? *value : 0;
+  }
+
+  void __set_MaxItemsToUse(int64_t value)
+  {
+    static auto property = get_class_helper().GetProperty("MaxItemsToUse");
+    property.SetRaw(this, value);
+  }
+
   bool __get_IsDonationUse()
   {
     static auto field = get_class_helper().GetProperty("IsDonationUse");
@@ -25,5 +42,12 @@ public:
   {
     static auto field = get_class_helper().GetProperty("IsDonationUse");
     return field.SetRaw(this, v);
+  }
+
+  bool __get_IsChestPurchase()
+  {
+    static auto property = get_class_helper().GetProperty("IsChestPurchase");
+    const auto* value    = property.Get<bool>(this);
+    return value ? *value : false;
   }
 };

--- a/mods/src/prime/InventoryUseRowWidget.h
+++ b/mods/src/prime/InventoryUseRowWidget.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "InventoryForPopup.h"
+#include "Widget.h"
+
+struct InventoryUseRowWidget : public Widget<InventoryForPopup, InventoryUseRowWidget> {
+public:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Inventories", "InventoryUseRowWidget");
+    return class_helper;
+  }
+
+private:
+  friend struct Widget<InventoryForPopup, InventoryUseRowWidget>;
+};


### PR DESCRIPTION
## Summary

- add the Windows-only `[ui].extend_chest_purchase_max` setting with a default and verified extension ceiling of 160
- hook `InventoryUseRowWidget::SetWidgetData` through netniV's existing `SPUD_STATIC_DETOUR`/`ErrorMsg` pattern
- raise only positive native limits on contexts tagged `IsChestPurchase`, while preserving disabled, higher-native, donation, artifact-conversion, and ordinary-inventory behavior
- add the required Prime bindings, localized example settings, and a concise README feature note

## Behavioral reference

Adapted from [`Guffawaffle/stfc-mod@05b0c10`](https://github.com/Guffawaffle/stfc-mod/commit/05b0c10031a2500bdb9615890e96aa7e34c077ca) (`Extend tagged chest purchase sliders`). This is a manual migration onto netniV's current structure; it does not include the reference fork's hook registry, manifests, probe documents, or other fork-specific infrastructure.

## Validation

- `git diff --check` — passed
- `xmake f -p windows -m release -y` — passed
- `xmake -y mods` — passed (`build ok`, 46.594s)
- GitHub Actions — Windows build, macOS arm64 build, macOS x86_64 build, and macOS packaging all passed
- final diff review — no hook-registry/manifests/probe-doc additions; existing alliance-donation hook unchanged

Runtime validation was not run: the game was stopped, this netniV branch has no AX facade/deploy workflow, and the available tooling cannot safely drive the interactive chest/donation/artifact/inventory slider UI without confirming a transaction.

Manual runtime checks remaining before promotion:

- [x] eligible custom-quantity chest reaches 160 without confirming a purchase
- [x] `[ui].extend_chest_purchase_max = 0` preserves the native chest limit
- [x] donation, artifact-conversion, and ordinary inventory sliders remain unchanged