### PR TITLE
feature/per ship insta jump config

### DIFF
--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -570,8 +570,24 @@ always_skip_reveal_sequence = true
 # Open the bulk gift claim flyout automatically
 auto_open_bulk_claim_flyout = false
 
-# Sofort-Warp-Aktion, die automatisch bestätigt wird: none, warp oder jump
+# Standardmäßige Instant-Warp-Aktion für alle Schiffe: none, warp oder jump.
+# Die Schiffsspezifischen Listen unten überschreiben dies für die jeweiligen Schiffe.
 auto_confirm_instant_warp = "none"
+
+# Schiffe, die immer per Instant Warp springen (überschreibt den Standard oben).
+# Durch Kommas getrennte Rumpfnamen (Groß-/Kleinschreibung egal), "*" für alle oder "" für keine.
+# Entspricht: auto_confirm_instant_warp = "jump" nur für diese Schiffe.
+# Beispiel: instant_warp_auto_jump = "USS Discovery, Korinar"
+instant_warp_auto_jump = ""
+
+# Schiffe, die immer regulär warpen (überschreibt den Standard oben).
+# Gleiche Syntax. Entspricht: auto_confirm_instant_warp = "warp" nur für diese Schiffe.
+# Beispiel: instant_warp_auto_warp = "Newton, USS Enterprise"
+instant_warp_auto_warp = ""
+
+# Schiffe, für die das Popup immer angezeigt wird (überschreibt alles andere).
+# Beispiel: instant_warp_always_ask = "Borg Cube, Gorn Eviscerator"
+instant_warp_always_ask = ""
 
 # Stufen- und Rangverbesserungen für Verbotene Technologie automatisch bestätigen
 auto_confirm_ft_upgrade = false

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -570,8 +570,24 @@ always_skip_reveal_sequence = true
 # Open the bulk gift claim flyout automatically
 auto_open_bulk_claim_flyout = false
 
-# Instant-warp action to confirm automatically: none, warp, or jump
+# Default instant-warp action for all ships: none, warp, or jump.
+# Per-ship lists below override this for matched ships.
 auto_confirm_instant_warp = "none"
+
+# Ships to always instant jump (override the default above).
+# Comma-separated hull names (case-insensitive), "*" for all, or "" for none.
+# Equivalent: auto_confirm_instant_warp = "jump" for these ships only.
+# Example: instant_warp_auto_jump = "USS Discovery, Korinar"
+instant_warp_auto_jump = ""
+
+# Ships to always regular warp (override the default above).
+# Same syntax. Equivalent: auto_confirm_instant_warp = "warp" for these ships only.
+# Example: instant_warp_auto_warp = "Newton, USS Enterprise-E"
+instant_warp_auto_warp = ""
+
+# Ships for which the popup is always shown, overriding everything else.
+# Example: instant_warp_always_ask = "Borg Cube, Gorn Eviscerator"
+instant_warp_always_ask = ""
 
 # Confirm Forbidden Tech level and tier upgrades automatically
 auto_confirm_ft_upgrade = false

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -570,8 +570,24 @@ always_skip_reveal_sequence = true
 # Open the bulk gift claim flyout automatically
 auto_open_bulk_claim_flyout = false
 
-# Action de distorsion instantanée à confirmer automatiquement : none, warp ou jump
+# Action de distorsion instantanée par défaut pour tous les vaisseaux : none, warp ou jump.
+# Les listes spécifiques ci-dessous remplacent cette valeur pour les vaisseaux correspondants.
 auto_confirm_instant_warp = "none"
+
+# Vaisseaux qui effectuent toujours un saut instantané (remplace le défaut ci-dessus).
+# Noms de coques séparés par des virgules (casse insensible), "*" pour tous, ou "" pour aucun.
+# Équivaut à : auto_confirm_instant_warp = "jump" pour ces vaisseaux seulement.
+# Exemple : instant_warp_auto_jump = "USS Discovery, Korinar"
+instant_warp_auto_jump = ""
+
+# Vaisseaux qui effectuent toujours une distorsion normale (remplace le défaut ci-dessus).
+# Même syntaxe. Équivaut à : auto_confirm_instant_warp = "warp" pour ces vaisseaux seulement.
+# Exemple : instant_warp_auto_warp = "Newton, USS Enterprise"
+instant_warp_auto_warp = ""
+
+# Vaisseaux pour lesquels la popup est toujours affichée (ignore tout le reste).
+# Exemple : instant_warp_always_ask = "Borg Cube, Gorn Eviscerator"
+instant_warp_always_ask = ""
 
 # Confirmer automatiquement les améliorations de niveau et de rang de Technologie interdite
 auto_confirm_ft_upgrade = false

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -570,8 +570,24 @@ always_skip_reveal_sequence = true
 # Open the bulk gift claim flyout automatically
 auto_open_bulk_claim_flyout = false
 
-# Instant-warpactie die automatisch wordt bevestigd: none, warp of jump
+# Standaard instant-warpactie voor alle schepen: none, warp of jump.
+# De scheepsspecifieke lijsten hieronder overschrijven dit voor de betreffende schepen.
 auto_confirm_instant_warp = "none"
+
+# Schepen die altijd instant springen (overschrijft de standaard hierboven).
+# Door komma's gescheiden rompnamen (hoofdlettergevoeligheid genegeerd), "*" voor alle, of "" voor geen.
+# Equivalent aan: auto_confirm_instant_warp = "jump" alleen voor deze schepen.
+# Voorbeeld: instant_warp_auto_jump = "USS Discovery, Korinar"
+instant_warp_auto_jump = ""
+
+# Schepen die altijd regulier warpen (overschrijft de standaard hierboven).
+# Zelfde syntax. Equivalent aan: auto_confirm_instant_warp = "warp" alleen voor deze schepen.
+# Voorbeeld: instant_warp_auto_warp = "Newton, USS Enterprise"
+instant_warp_auto_warp = ""
+
+# Schepen waarvoor de popup altijd wordt getoond (overschrijft alles anders).
+# Voorbeeld: instant_warp_always_ask = "Borg Cube, Gorn Eviscerator"
+instant_warp_always_ask = ""
 
 # Level- en rangupgrades voor Verboden Technologie automatisch bevestigen
 auto_confirm_ft_upgrade = false

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -420,6 +420,38 @@ InstantWarpConfirmation get_auto_confirm_instant_warp(toml::table& config, toml:
   return confirmation;
 }
 
+void parse_ship_filter(std::string_view value, std::vector<std::string>& names, bool& match_all)
+{
+  names.clear();
+  match_all = false;
+  if (AsciiStrToUpper(StripAsciiWhitespace(value)) == "*") {
+    match_all = true;
+    return;
+  }
+  for (const auto& token : StrSplit(std::string(value), ',')) {
+    auto stripped = StripLeadingAsciiWhitespace(token);
+    if (stripped.empty()) continue;
+    auto normalized = AsciiStrToUpper(stripped);
+    normalized = StripSuffix(normalized, "_LIVE");
+    names.emplace_back(normalized);
+  }
+}
+
+void read_instant_warp_filter(toml::table& config, toml::table& new_config, std::string_view key,
+                              std::vector<std::string>& names, bool& match_all,
+                              std::string_view default_value, bool write_log)
+{
+  const auto value = config["ui"][key].value<std::string>().value_or(std::string(default_value));
+  parse_ship_filter(value, names, match_all);
+
+  new_config.emplace<toml::table>("ui", toml::table());
+  new_config["ui"].as_table()->insert_or_assign(std::string(key), std::string(value));
+
+  if (write_log) {
+    spdlog::debug("config value ui.{}: {}", key, value);
+  }
+}
+
 void read_sync_targets(toml::table& config, toml::table& new_config,
                        std::map<std::string, SyncTargetConfig>& sync_targets, const SyncConfig& defaults)
 {
@@ -863,10 +895,17 @@ void Config::Load()
       get_config_or_default(config, parsed, "ui", "disable_toast_banners", DCU::disable_toast_banners, write_config);
   this->auto_open_bulk_claim_flyout = get_config_or_default(config, parsed, "ui", "auto_open_bulk_claim_flyout",
                                                             DCU::auto_open_bulk_claim_flyout, write_config);
+  this->installInstantWarpConfirmationHooks = true;
+
   this->auto_confirm_instant_warp =
       get_auto_confirm_instant_warp(config, parsed, DCU::auto_confirm_instant_warp, write_config);
-  this->installInstantWarpConfirmationHooks = true;
-  
+  read_instant_warp_filter(config, parsed, "instant_warp_auto_jump", this->instant_warp_auto_jump,
+                           this->instant_warp_auto_jump_all, DCU::instant_warp_auto_jump, write_config);
+  read_instant_warp_filter(config, parsed, "instant_warp_auto_warp", this->instant_warp_auto_warp,
+                           this->instant_warp_auto_warp_all, DCU::instant_warp_auto_warp, write_config);
+  read_instant_warp_filter(config, parsed, "instant_warp_always_ask", this->instant_warp_always_ask,
+                           this->instant_warp_always_ask_all, DCU::instant_warp_always_ask, write_config);
+
   this->auto_confirm_ft_upgrade =
       get_config_or_default(config, parsed, "ui", "auto_confirm_ft_upgrade",
                             DCU::auto_confirm_ft_upgrade, write_config);

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -429,10 +429,9 @@ void parse_ship_filter(std::string_view value, std::vector<std::string>& names, 
     return;
   }
   for (const auto& token : StrSplit(std::string(value), ',')) {
-    auto stripped = StripLeadingAsciiWhitespace(token);
+    auto stripped = StripAsciiWhitespace(token);
     if (stripped.empty()) continue;
     auto normalized = AsciiStrToUpper(stripped);
-    normalized = StripSuffix(normalized, "_LIVE");
     names.emplace_back(normalized);
   }
 }
@@ -895,10 +894,9 @@ void Config::Load()
       get_config_or_default(config, parsed, "ui", "disable_toast_banners", DCU::disable_toast_banners, write_config);
   this->auto_open_bulk_claim_flyout = get_config_or_default(config, parsed, "ui", "auto_open_bulk_claim_flyout",
                                                             DCU::auto_open_bulk_claim_flyout, write_config);
-  this->installInstantWarpConfirmationHooks = true;
-
   this->auto_confirm_instant_warp =
       get_auto_confirm_instant_warp(config, parsed, DCU::auto_confirm_instant_warp, write_config);
+  this->installInstantWarpConfirmationHooks = true;
   read_instant_warp_filter(config, parsed, "instant_warp_auto_jump", this->instant_warp_auto_jump,
                            this->instant_warp_auto_jump_all, DCU::instant_warp_auto_jump, write_config);
   read_instant_warp_filter(config, parsed, "instant_warp_auto_warp", this->instant_warp_auto_warp,

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -198,6 +198,14 @@ public:
 
   InstantWarpConfirmation auto_confirm_instant_warp;
 
+  std::vector<std::string> instant_warp_auto_jump;
+  std::vector<std::string> instant_warp_auto_warp;
+  bool                     instant_warp_auto_jump_all = false;
+  bool                     instant_warp_auto_warp_all = false;
+
+  std::vector<std::string> instant_warp_always_ask;
+  bool                     instant_warp_always_ask_all = false;
+
   bool show_cargo_default;
   bool show_player_cargo;
   bool show_station_cargo;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -224,6 +224,9 @@ namespace UI
   constexpr const char* hud_outposts                = "auto";
   constexpr const char* hud_q_trials                = "auto";
   constexpr const char* auto_confirm_instant_warp   = "none";
+  constexpr const char* instant_warp_auto_jump     = "";
+  constexpr const char* instant_warp_auto_warp     = "";
+  constexpr const char* instant_warp_always_ask    = "";
   constexpr const char* notify_banner_types         = "";
   constexpr auto        extend_donation_max         = 80;
   constexpr bool        extend_donation_slider      = true;

--- a/mods/src/patches/parts/instant_warp_confirmation.cc
+++ b/mods/src/patches/parts/instant_warp_confirmation.cc
@@ -7,6 +7,8 @@
 
 #include <spud/detour.h>
 
+#include <spdlog/spdlog.h>
+
 #include <algorithm>
 
 namespace
@@ -46,22 +48,27 @@ void CoursePromptPopupViewController_AboutToShow_Hook(auto original, CoursePromp
   };
 
   if (matches(cfg.instant_warp_always_ask, cfg.instant_warp_always_ask_all)) {
+    spdlog::debug("InstantWarpConfirmation: always_ask matched hull '{}', showing popup", hull_name);
     return;
   }
   if (matches(cfg.instant_warp_auto_jump, cfg.instant_warp_auto_jump_all)) {
+    spdlog::debug("InstantWarpConfirmation: auto_jump matched hull '{}', selecting instant warp", hull_name);
     on_instant_warp_button_click(widget);
     return;
   }
   if (matches(cfg.instant_warp_auto_warp, cfg.instant_warp_auto_warp_all)) {
+    spdlog::debug("InstantWarpConfirmation: auto_warp matched hull '{}', selecting regular warp", hull_name);
     initiate_regular_warp(widget);
     return;
   }
 
   switch (cfg.auto_confirm_instant_warp) {
     case InstantWarpConfirmation::Warp:
+      spdlog::debug("InstantWarpConfirmation: default matched hull '{}', selecting regular warp", hull_name);
       initiate_regular_warp(widget);
       break;
     case InstantWarpConfirmation::Jump:
+      spdlog::debug("InstantWarpConfirmation: default matched hull '{}', selecting instant warp", hull_name);
       on_instant_warp_button_click(widget);
       break;
     case InstantWarpConfirmation::None:

--- a/mods/src/patches/parts/instant_warp_confirmation.cc
+++ b/mods/src/patches/parts/instant_warp_confirmation.cc
@@ -1,10 +1,13 @@
 #include "config.h"
 #include "errormsg.h"
+#include "str_utils.h"
 
+#include <prime/CourseData.h>
 #include <prime/CoursePromptPopupWidget.h>
 
 #include <spud/detour.h>
-#include <spdlog/spdlog.h>
+
+#include <algorithm>
 
 namespace
 {
@@ -22,13 +25,43 @@ void CoursePromptPopupViewController_AboutToShow_Hook(auto original, CoursePromp
     return;
   }
 
-  switch (Config::Get().auto_confirm_instant_warp) {
+  const auto& cfg = Config::Get();
+
+  std::string hull_name;
+  if (const auto course = context->GetCourseData(); course != nullptr) {
+    if (const auto fleet = course->PlayerFleet; fleet != nullptr) {
+      if (const auto hull = fleet->Hull; hull != nullptr) {
+        if (const auto name = hull->Name; name != nullptr) {
+          hull_name = AsciiStrToUpper(to_string(name));
+          hull_name = StripSuffix(hull_name, "_LIVE");
+        }
+      }
+    }
+  }
+
+  const auto matches = [&hull_name](const std::vector<std::string>& names, bool all) -> bool {
+    if (all) return true;
+    if (hull_name.empty()) return false;
+    return std::ranges::any_of(names, [&](const auto& s) { return s == hull_name; });
+  };
+
+  if (matches(cfg.instant_warp_always_ask, cfg.instant_warp_always_ask_all)) {
+    return;
+  }
+  if (matches(cfg.instant_warp_auto_jump, cfg.instant_warp_auto_jump_all)) {
+    on_instant_warp_button_click(widget);
+    return;
+  }
+  if (matches(cfg.instant_warp_auto_warp, cfg.instant_warp_auto_warp_all)) {
+    initiate_regular_warp(widget);
+    return;
+  }
+
+  switch (cfg.auto_confirm_instant_warp) {
     case InstantWarpConfirmation::Warp:
-      spdlog::debug("InstantWarpConfirmation: selecting regular warp during popup show");
       initiate_regular_warp(widget);
       break;
     case InstantWarpConfirmation::Jump:
-      spdlog::debug("InstantWarpConfirmation: selecting instant warp during popup show");
       on_instant_warp_button_click(widget);
       break;
     case InstantWarpConfirmation::None:

--- a/mods/src/prime/CourseData.h
+++ b/mods/src/prime/CourseData.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "FleetPlayerData.h"
+
+#include <il2cpp/il2cpp_helper.h>
+
+struct CourseData {
+public:
+  __declspec(property(get = __get_PlayerFleet)) FleetPlayerData* PlayerFleet;
+
+  FleetPlayerData* __get_PlayerFleet()
+  {
+    static auto field = get_class_helper().GetProperty("PlayerFleet");
+    return field.GetRaw<FleetPlayerData>(this);
+  }
+
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "CourseData");
+    return class_helper;
+  }
+};

--- a/mods/src/prime/CoursePromptPopupWidget.h
+++ b/mods/src/prime/CoursePromptPopupWidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "CourseData.h"
 #include "GenericButtonWidget.h"
 #include "Widget.h"
 
@@ -14,6 +15,12 @@ public:
   {
     static auto field = get_class_helper().GetField("HasInstantWarp");
     return *(bool*)((char*)this + field.offset());
+  }
+
+  CourseData* GetCourseData()
+  {
+    static auto field = get_class_helper().GetField("CourseData");
+    return *(CourseData**)((char*)this + field.offset());
   }
 
 private:

--- a/mods/src/str_utils.h
+++ b/mods/src/str_utils.h
@@ -39,6 +39,14 @@ constexpr std::string_view StripAsciiWhitespace(const std::string_view str)
   return StripTrailingAsciiWhitespace(StripLeadingAsciiWhitespace(str));
 }
 
+constexpr std::string_view StripSuffix(std::string_view str, const std::string_view suffix)
+{
+  if (str.size() >= suffix.size() && str.substr(str.size() - suffix.size()) == suffix) {
+    return str.substr(0, str.size() - suffix.size());
+  }
+  return str;
+}
+
 constexpr std::string AsciiStrToUpper(const std::string_view s)
 {
   std::string str = s.data();


### PR DESCRIPTION
## Scope

This PR adds per-ship auto-jump/auto-warp configuration to the existing instant-warp confirmation feature. The global `auto_confirm_instant_warp` setting is preserved as the default; the new per-ship lists override it for matched ship names. No other patch behavior is modified.

## Summary

- adds three new `[ui]` settings: `instant_warp_auto_jump`, `instant_warp_auto_warp`, and `instant_warp_always_ask`, each a comma-separated list of ship names (case-insensitive), with `*` matching all ships and `""` matching none
- reads the active hull name from the course popup's `CourseData -> PlayerFleet -> Hull -> Name`, normalizing to uppercase and stripping the `_LIVE` suffix used for live-server hull variants
- evaluates the lists with precedence `always_ask` > `auto_jump` > `auto_warp` > global default, so an `always_ask` match always shows the popup even if the ship also appears in an auto list
- adds a `parse_ship_filter` / `read_instant_warp_filter` config helper and a `StripSuffix` string utility
- documents the new settings in all four localized example configs (`en`, `de`, `fr`, `nl`)
- adds a `CourseData.h` prime header mirroring the game's `Digit.PrimeServer.Models.CourseData` and exposes `GetCourseData()` on `CoursePromptPopupWidget`

## Evidence and root cause

The existing `auto_confirm_instant_warp` setting is global: it applies one action (`none`, `warp`, or `jump`) to every ship. Players who want instant jump on some hulls but regular warp on others — or who want to always confirm on a few expensive ships — had no way to express that without changing the global default each time.

The fix reads the hull name from the popup context and matches it against the three new per-ship lists before falling back to the global default. Matching is case-insensitive and strips the `_LIVE` suffix so live-server hull variants match the same config entry as their base hull.

## Validation

- the existing global `auto_confirm_instant_warp` path is unchanged and still applies when no per-ship list matches

## Player test plan

1. Install the artifact built from this branch.
2. Set `auto_confirm_instant_warp = "none"` (global default) and leave the three per-ship lists empty; confirm the warp popup still appears for every ship as before.
3. Add a hull to `instant_warp_auto_jump` (e.g. `"USS Discovery"`) and confirm that ship auto-instant-jumps while others still show the popup.
4. Add a hull to `instant_warp_auto_warp` and confirm it auto-regular-warps.
5. Add a hull to `instant_warp_always_ask` that also appears in an auto list and confirm the popup is shown (precedence check).
6. Set `instant_warp_auto_jump = "*"` and confirm every ship auto-instant-jumps regardless of the global default.
7. Verify hull-name matching is case-insensitive.

## Risk and fallback

Per-ship lists are only consulted when populated; an empty list (the default) falls through to the existing global `auto_confirm_instant_warp` behavior, so this is additive. If a hull name cannot be resolved at runtime (null `CourseData`/`Hull`), all per-ship matches fail safely and the global default applies. To revert to the previous behavior, leave the three new settings empty. 
Depends on users inputting the correct ship names - although I tried to normalise the config in a way that allows you to input the displayed name of the ship instead of the internal Scopely name (which for weird reasons has a "_LIVE" suffix sometimes). 

*Disclaimer: This can break if Scopely decides to rename ships internally or releases ships with odd hull names. Don't merge this PR if this feels too hacky and setup intensive.*