### PR TITLE
fix: pass valid finalize mark proc to GC_register_finalizer_inner

### DIFF
--- a/mods/src/patches/parts/object_tracker.cc
+++ b/mods/src/patches/parts/object_tracker.cc
@@ -70,14 +70,25 @@ void remove_from_tracking_recursive(Il2CppClass* klass, void* _this)
 #undef GET_CLASS
 }
 
+// Unity's Boehm GC fork passes a per-entry "finalize mark proc" as a 6th argument to
+// GC_register_finalizer_inner. GC_finalize calls it for every unreachable finalized object, and the
+// game's own registrations (via GC_register_finalizer_no_order) always pass GC_null_finalize_mark_proc,
+// a no-op. If the 6th argument is omitted, register/stack garbage ends up in the finalization entry and
+// GC_finalize eventually calls it (observed as a call to nullptr -> SIGSEGV during ReclaimUnusedMemory).
+void gc_finalize_mark_proc_noop(void*)
+{
+}
+
 void (*GC_register_finalizer_inner)(unsigned __int64 obj, void (*fn)(void*, void*), void* cd,
-                                    void (**ofn)(void*, void*), void** ocd) = nullptr;
+                                    void (**ofn)(void*, void*), void** ocd, void (*mark_proc)(void*)) = nullptr;
 
 void track_finalizer(void* _this, void*)
 {
   if (_this == nullptr) {
     return;
   }
+
+  std::scoped_lock lk{tracked_objects_mutex};
 
   auto object = (Il2CppObject*)_this;
   if (object->klass == nullptr) {
@@ -109,7 +120,8 @@ void* track_ctor(auto original, void* _this)
     typedef void (*FinalizerCallback)(void* object, void* client_data);
     FinalizerCallback oldCallback = nullptr;
     void*             oldData     = nullptr;
-    GC_register_finalizer_inner((intptr_t)_this, track_finalizer, nullptr, &oldCallback, &oldData);
+    GC_register_finalizer_inner((intptr_t)_this, track_finalizer, nullptr, &oldCallback, &oldData,
+                                gc_finalize_mark_proc_noop);
     assert(!oldCallback);
   }
   add_to_tracking_recursive(cls->klass, _this);


### PR DESCRIPTION
## Summary

Fixes an intermittent SIGSEGV in `GC_finalize` when the object tracker patch is enabled (`objecttracker = true`).

**Root cause:** Unity's Boehm GC fork takes a **6th "finalize mark proc" argument** to `GC_register_finalizer_inner`. It is stored in the finalization entry and called by `GC_finalize` for every unreachable finalized object. `track_ctor` declared the function pointer with only 5 args, so the entry captured register/stack garbage, and the periodic `ReclaimUnusedMemoryRoutine` collection eventually called it — observed as `EXC_BAD_ACCESS` calling `nullptr` (macOS arm64, game build 1.000.51558):

```
0x0                      ← pc=0: call to null
GC_finalize              ← blr x8; x8 = [finalization_entry + 0x28]
GC_finish_collection
GC_try_to_collect_inner
GC_gcollect
<ReclaimUnusedMemoryRoutine>d__192_MoveNext
```

**Fix:** pass a no-op mark proc, mirroring the game's own registrations via `GC_register_finalizer_no_order` (which loads `GC_null_finalize_mark_proc` as the 6th arg — verified by disassembly on both arm64 and x86_64 slices of GameAssembly 51558). The fix is ABI-correct on all platforms (arm64 x5, SysV r9, Win64 stack slot); on any old game build where `_inner` took only 5 args the extra argument is ignored.

Also take `tracked_objects_mutex` in `track_finalizer` — it is invoked on the il2cpp finalizer thread and raced with main-thread `track_ctor`/`track_destroy`/`calc_liveness_hook` mutations. No deadlock risk: bdwgc invokes finalizers after releasing the GC lock, and `track_finalizer` makes no GC calls while holding the mutex.

## Verification

- Reproduced crash dump analysis end-to-end (call site LR matches `GC_finalize+0x164` in GameAssembly 51558).
- Rebuilt dylib verified at instruction level: call site now initializes x5 with the noop (a single `ret`, byte-identical behavior to `GC_null_finalize_mark_proc`).
- Tested in-game with `objecttracker = true` (the previously crashing configuration).

Note: the existing arm64/x64 signatures for `GC_register_finalizer_inner` were verified to still match the real function in build 51558 — no signature drift.