### PR TITLE
Bugfix/suppress store popups

### DIFF
--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -579,8 +579,11 @@ auto_confirm_ft_upgrade = false
 # Verhindert, dass die Escape-Taste zum Beenden des Spiels auffordert
 disable_escape_exit = true
 
-# ⚠️ EXPERIMENTELL: Verhindert das Erscheinen des ersten Werbe-Pop-ups
+# ⚠️ EXPERIMENTELL: Verhindert das Erscheinen von Werbe-/Interstitial-Pop-ups
 disable_first_popup = false
+
+# ⚠️ EXPERIMENTELL: Verhindert das Erscheinen von Tutorial-/Hinweis-Pop-ups
+disable_tutorials = false
 
 # ⚠️ EXPERIMENTELL: Verhindert die Funktion der standardmäßigen Bewegungstasten
 disable_move_keys = false

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -579,8 +579,8 @@ auto_confirm_ft_upgrade = false
 # Verhindert, dass die Escape-Taste zum Beenden des Spiels auffordert
 disable_escape_exit = true
 
-# ⚠️ EXPERIMENTELL: Verhindert das Erscheinen von Werbe-/Interstitial-Pop-ups
-disable_first_popup = false
+# ⚠️ EXPERIMENTELL: Zeigt nur das erste Werbe-/Interstitial-Pop-up nach dem Start des Spiels an und unterdrückt die übrigen
+only_show_first_popup = false
 
 # ⚠️ EXPERIMENTELL: Verhindert die Funktion der standardmäßigen Bewegungstasten
 disable_move_keys = false

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -582,9 +582,6 @@ disable_escape_exit = true
 # ⚠️ EXPERIMENTELL: Verhindert das Erscheinen von Werbe-/Interstitial-Pop-ups
 disable_first_popup = false
 
-# ⚠️ EXPERIMENTELL: Verhindert das Erscheinen von Tutorial-/Hinweis-Pop-ups
-disable_tutorials = false
-
 # ⚠️ EXPERIMENTELL: Verhindert die Funktion der standardmäßigen Bewegungstasten
 disable_move_keys = false
 

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -579,8 +579,11 @@ auto_confirm_ft_upgrade = false
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
-# ⚠️ EXPERIMENTAL: Prevent the first popup advert from appearing
+# ⚠️ EXPERIMENTAL: Prevent ad/interstitial popups from appearing
 disable_first_popup = false
+
+# ⚠️ EXPERIMENTAL: Prevent tutorial/hint popups from appearing
+disable_tutorials = false
 
 # ⚠️ EXPERIMENTAL: Prevent the standard move keys from working
 disable_move_keys = false

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -579,8 +579,8 @@ auto_confirm_ft_upgrade = false
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
-# ⚠️ EXPERIMENTAL: Prevent ad/interstitial popups from appearing
-disable_first_popup = false
+# ⚠️ EXPERIMENTAL: Show only the first ad/interstitial popup after the game starts, then suppress the rest
+only_show_first_popup = false
 
 # ⚠️ EXPERIMENTAL: Prevent the standard move keys from working
 disable_move_keys = false

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -582,9 +582,6 @@ disable_escape_exit = true
 # ⚠️ EXPERIMENTAL: Prevent ad/interstitial popups from appearing
 disable_first_popup = false
 
-# ⚠️ EXPERIMENTAL: Prevent tutorial/hint popups from appearing
-disable_tutorials = false
-
 # ⚠️ EXPERIMENTAL: Prevent the standard move keys from working
 disable_move_keys = false
 

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -579,8 +579,8 @@ auto_confirm_ft_upgrade = false
 # Empêcher "échap" de proposer de quitter le jeu
 disable_escape_exit = true
 
-# ⚠️ EXPÉRIMENTAL : Empêcher les publicités/interstitiels pop-up d'apparaître
-disable_first_popup = false
+# ⚠️ EXPÉRIMENTAL : Afficher uniquement la première publicité/interstitiel pop-up après le démarrage du jeu, puis supprimer les suivantes
+only_show_first_popup = false
 
 # ⚠️ EXPÉRIMENTAL : Empêcher les touches de déplacement standard de fonctionner
 disable_move_keys = false

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -582,9 +582,6 @@ disable_escape_exit = true
 # ⚠️ EXPÉRIMENTAL : Empêcher les publicités/interstitiels pop-up d'apparaître
 disable_first_popup = false
 
-# ⚠️ EXPÉRIMENTAL : Empêcher les tutoriels/infobulles pop-up d'apparaître
-disable_tutorials = false
-
 # ⚠️ EXPÉRIMENTAL : Empêcher les touches de déplacement standard de fonctionner
 disable_move_keys = false
 

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -579,8 +579,11 @@ auto_confirm_ft_upgrade = false
 # Empêcher "échap" de proposer de quitter le jeu
 disable_escape_exit = true
 
-# ⚠️ EXPÉRIMENTAL : Empêcher la première publicité pop-up d'apparaître
+# ⚠️ EXPÉRIMENTAL : Empêcher les publicités/interstitiels pop-up d'apparaître
 disable_first_popup = false
+
+# ⚠️ EXPÉRIMENTAL : Empêcher les tutoriels/infobulles pop-up d'apparaître
+disable_tutorials = false
 
 # ⚠️ EXPÉRIMENTAL : Empêcher les touches de déplacement standard de fonctionner
 disable_move_keys = false

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -579,8 +579,11 @@ auto_confirm_ft_upgrade = false
 # Zorgt ervoor dat het gebruiken van "escape" het spel niet sluit
 disable_escape_exit = true
 
-# ⚠️ EXPERIMENTEEL: Zorgt ervoor dat de eerste advertentie popup niet toont
+# ⚠️ EXPERIMENTEEL: Zorgt ervoor dat advertentie/interstitial pop-ups niet verschijnen
 disable_first_popup = false
+
+# ⚠️ EXPERIMENTEEL: Zorgt ervoor dat tutorial/hint pop-ups niet verschijnen
+disable_tutorials = false
 
 # ⚠️ EXPERIMENTEEL: Zorgt ervoor dat de standaard toetsenbord toetsen voor het bewegen niet werken
 disable_move_keys = false

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -579,8 +579,8 @@ auto_confirm_ft_upgrade = false
 # Zorgt ervoor dat het gebruiken van "escape" het spel niet sluit
 disable_escape_exit = true
 
-# ⚠️ EXPERIMENTEEL: Zorgt ervoor dat advertentie/interstitial pop-ups niet verschijnen
-disable_first_popup = false
+# ⚠️ EXPERIMENTEEL: Toont alleen de eerste advertentie/interstitial pop-up na het starten van het spel en onderdrukt de rest
+only_show_first_popup = false
 
 # ⚠️ EXPERIMENTEEL: Zorgt ervoor dat de standaard toetsenbord toetsen voor het bewegen niet werken
 disable_move_keys = false

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -582,9 +582,6 @@ disable_escape_exit = true
 # ⚠️ EXPERIMENTEEL: Zorgt ervoor dat advertentie/interstitial pop-ups niet verschijnen
 disable_first_popup = false
 
-# ⚠️ EXPERIMENTEEL: Zorgt ervoor dat tutorial/hint pop-ups niet verschijnen
-disable_tutorials = false
-
 # ⚠️ EXPERIMENTEEL: Zorgt ervoor dat de standaard toetsenbord toetsen voor het bewegen niet werken
 disable_move_keys = false
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -857,6 +857,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "ui", "disable_preview_recall", DCU::disable_preview_recall, write_config);
   this->disable_first_popup =
       get_config_or_default(config, parsed, "ui", "disable_first_popup", DCU::disable_first_popup, write_config);
+  this->disable_tutorials =
+      get_config_or_default(config, parsed, "ui", "disable_tutorials", DCU::disable_tutorials, write_config);
   this->disable_move_keys =
       get_config_or_default(config, parsed, "ui", "disable_move_keys", DCU::disable_move_keys, write_config);
   this->disable_toast_banners =

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -855,8 +855,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "ui", "disable_preview_locate", DCU::disable_preview_locate, write_config);
   this->disable_preview_recall =
       get_config_or_default(config, parsed, "ui", "disable_preview_recall", DCU::disable_preview_recall, write_config);
-  this->disable_first_popup =
-      get_config_or_default(config, parsed, "ui", "disable_first_popup", DCU::disable_first_popup, write_config);
+  this->only_show_first_popup = get_config_or_default(config, parsed, "ui", "only_show_first_popup",
+                                                      DCU::only_show_first_popup, write_config);
   this->disable_move_keys =
       get_config_or_default(config, parsed, "ui", "disable_move_keys", DCU::disable_move_keys, write_config);
   this->disable_toast_banners =

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -857,8 +857,6 @@ void Config::Load()
       get_config_or_default(config, parsed, "ui", "disable_preview_recall", DCU::disable_preview_recall, write_config);
   this->disable_first_popup =
       get_config_or_default(config, parsed, "ui", "disable_first_popup", DCU::disable_first_popup, write_config);
-  this->disable_tutorials =
-      get_config_or_default(config, parsed, "ui", "disable_tutorials", DCU::disable_tutorials, write_config);
   this->disable_move_keys =
       get_config_or_default(config, parsed, "ui", "disable_move_keys", DCU::disable_move_keys, write_config);
   this->disable_toast_banners =

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -191,7 +191,7 @@ public:
   bool disable_escape_exit;
   bool disable_galaxy_chat;
   bool disable_veil_chat;
-  bool disable_first_popup;
+  bool only_show_first_popup;
   bool disable_toast_banners;
   bool auto_open_bulk_claim_flyout;
   bool auto_confirm_ft_upgrade;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -192,7 +192,6 @@ public:
   bool disable_galaxy_chat;
   bool disable_veil_chat;
   bool disable_first_popup;
-  bool disable_tutorials;
   bool disable_toast_banners;
   bool auto_open_bulk_claim_flyout;
   bool auto_confirm_ft_upgrade;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -192,6 +192,7 @@ public:
   bool disable_galaxy_chat;
   bool disable_veil_chat;
   bool disable_first_popup;
+  bool disable_tutorials;
   bool disable_toast_banners;
   bool auto_open_bulk_claim_flyout;
   bool auto_confirm_ft_upgrade;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -211,6 +211,7 @@ namespace UI
   constexpr bool        auto_open_bulk_claim_flyout = false;
   constexpr bool        disable_escape_exit         = true;
   constexpr bool        disable_first_popup         = false;
+  constexpr bool        disable_tutorials          = false;
   constexpr bool        disable_galaxy_chat         = false;
   constexpr bool        disable_move_keys           = false;
   constexpr bool        disable_preview_locate      = false;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -210,7 +210,7 @@ namespace UI
   constexpr bool        auto_confirm_ft_upgrade     = false;
   constexpr bool        auto_open_bulk_claim_flyout = false;
   constexpr bool        disable_escape_exit         = true;
-  constexpr bool        disable_first_popup         = false;
+  constexpr bool        only_show_first_popup       = false;
   constexpr bool        disable_galaxy_chat         = false;
   constexpr bool        disable_move_keys           = false;
   constexpr bool        disable_preview_locate      = false;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -211,7 +211,6 @@ namespace UI
   constexpr bool        auto_open_bulk_claim_flyout = false;
   constexpr bool        disable_escape_exit         = true;
   constexpr bool        disable_first_popup         = false;
-  constexpr bool        disable_tutorials          = false;
   constexpr bool        disable_galaxy_chat         = false;
   constexpr bool        disable_move_keys           = false;
   constexpr bool        disable_preview_locate      = false;

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -187,11 +187,11 @@ public:
 
 void InterstitialViewController_AboutToShow(auto original, InterstitialViewController* _this)
 {
-  if (Config::Get().disable_first_popup) {
-    spdlog::debug("InterstitialViewController_AboutToShow: suppressing interstitial popup");
-    return;
-  }
   original(_this);
+  if (Config::Get().disable_first_popup && _this != nullptr) {
+    spdlog::debug("InterstitialViewController_AboutToShow: suppressing interstitial popup");
+    _this->CloseWhenReady();
+  }
 }
 
 void ShopSceneManager_ShowPlcOfferPopup(auto original, void* _this)

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -204,29 +204,6 @@ void ShopSceneManager_ShowPlcOfferPopup(auto original, void* _this)
   original(_this);
 }
 
-bool LoginStreakManager_TryShowStreakPopupForGameSessionStarted(auto original, void* _this)
-{
-  if (Config::Get().disable_first_popup) {
-    spdlog::debug("LoginStreakManager_TryShowStreakPopupForGameSessionStarted: suppressing login streak popup");
-    return false;
-  }
-  return original(_this);
-}
-
-void TutorialManager_ShowTutorialScreen(auto original, void* _this)
-{
-  if (!Config::Get().disable_tutorials) {
-    original(_this);
-  }
-}
-
-void TutorialManager_ShowTutorialScreen_2(auto original, void* _this, void* tutorialComponent, void* tutorialStep)
-{
-  if (!Config::Get().disable_tutorials) {
-    original(_this, tutorialComponent, tutorialStep);
-  }
-}
-
 void ActionQueueManager_AddActionToQueue(auto original, ActionQueueManager* _this, long fleet_id)
 {
   spdlog::warn("ActionQueueManager_AddActionToQueue({})", fleet_id);
@@ -250,7 +227,7 @@ void InstallTempCrashFixes()
     }
   }
 
-  auto shop_scene_manager = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Shop", "ShopSceneManager");
+  static auto shop_scene_manager = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Shop", "ShopSceneManager");
   if (!shop_scene_manager.isValidHelper()) {
     ErrorMsg::MissingHelper("Shop", "ShopSceneManager");
   } else {
@@ -259,6 +236,13 @@ void InstallTempCrashFixes()
       ErrorMsg::MissingMethod("ShopSceneManager", "ShouldShowRevealSequence");
     } else {
       SPUD_STATIC_DETOUR(reveal_show, ShouldShowRevealHook);
+    }
+
+    auto show_plc = shop_scene_manager.GetMethod("ShowPlcOfferPopup", 0);
+    if (!show_plc) {
+      ErrorMsg::MissingMethod("ShopSceneManager", "ShowPlcOfferPopup");
+    } else {
+      SPUD_STATIC_DETOUR(show_plc, ShopSceneManager_ShowPlcOfferPopup);
     }
   }
 
@@ -272,51 +256,6 @@ void InstallTempCrashFixes()
       ErrorMsg::MissingMethod("InterstitialViewController", "AboutToShow");
     } else {
       SPUD_STATIC_DETOUR(interstitial_show, InterstitialViewController_AboutToShow);
-    }
-  }
-
-  static auto shop_scene_manager_cls =
-      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Shop", "ShopSceneManager");
-  if (!shop_scene_manager_cls.isValidHelper()) {
-    ErrorMsg::MissingHelper("Shop", "ShopSceneManager");
-  } else {
-    auto show_plc = shop_scene_manager_cls.GetMethod("ShowPlcOfferPopup", 0);
-    if (!show_plc) {
-      ErrorMsg::MissingMethod("ShopSceneManager", "ShowPlcOfferPopup");
-    } else {
-      SPUD_STATIC_DETOUR(show_plc, ShopSceneManager_ShowPlcOfferPopup);
-    }
-  }
-
-  static auto login_streak_manager =
-      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.LoginStreak", "LoginStreakManager");
-  if (!login_streak_manager.isValidHelper()) {
-    ErrorMsg::MissingHelper("LoginStreak", "LoginStreakManager");
-  } else {
-    auto show_streak = login_streak_manager.GetMethod("TryShowStreakPopupForGameSessionStarted", 0);
-    if (!show_streak) {
-      ErrorMsg::MissingMethod("LoginStreakManager", "TryShowStreakPopupForGameSessionStarted");
-    } else {
-      SPUD_STATIC_DETOUR(show_streak, LoginStreakManager_TryShowStreakPopupForGameSessionStarted);
-    }
-  }
-
-  static auto tutorial_manager =
-      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Tutorial", "TutorialManager");
-  if (!tutorial_manager.isValidHelper()) {
-    ErrorMsg::MissingHelper("Tutorial", "TutorialManager");
-  } else {
-    auto show_tutorial_screen = tutorial_manager.GetMethod("ShowTutorialScreen", 0);
-    if (!show_tutorial_screen) {
-      ErrorMsg::MissingMethod("TutorialManager", "ShowTutorialScreen");
-    } else {
-      SPUD_STATIC_DETOUR(show_tutorial_screen, TutorialManager_ShowTutorialScreen);
-    }
-    auto show_tutorial_screen_2 = tutorial_manager.GetMethod("ShowTutorialScreen", 2);
-    if (!show_tutorial_screen_2) {
-      ErrorMsg::MissingMethod("TutorialManager", "ShowTutorialScreen(2)");
-    } else {
-      SPUD_STATIC_DETOUR(show_tutorial_screen_2, TutorialManager_ShowTutorialScreen_2);
     }
   }
 

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -17,6 +17,7 @@
 #endif
 
 #include <algorithm>
+#include <atomic>
 #include <prime/ActionQueueManager.h>
 #include <prime/InterstitialViewController.h>
 
@@ -185,19 +186,31 @@ public:
   }
 };
 
+static std::atomic_bool g_first_popup_shown{false};
+
+bool ShouldSuppressAdditionalPopup()
+{
+  bool expected = false;
+  return !g_first_popup_shown.compare_exchange_strong(expected, true);
+}
+
 void InterstitialViewController_AboutToShow(auto original, InterstitialViewController* _this)
 {
   original(_this);
-  if (Config::Get().disable_first_popup && _this != nullptr) {
-    spdlog::debug("InterstitialViewController_AboutToShow: suppressing interstitial popup");
-    _this->CloseWhenReady();
+  if (Config::Get().only_show_first_popup && _this != nullptr) {
+    if (ShouldSuppressAdditionalPopup()) {
+      spdlog::debug("InterstitialViewController_AboutToShow: suppressing interstitial popup (already shown one)");
+      _this->CloseWhenReady();
+    } else {
+      spdlog::debug("InterstitialViewController_AboutToShow: allowing first popup of the session to show");
+    }
   }
 }
 
 void ShopSceneManager_ShowPlcOfferPopup(auto original, void* _this)
 {
-  if (Config::Get().disable_first_popup) {
-    spdlog::debug("ShopSceneManager_ShowPlcOfferPopup: suppressing PLC offer popup");
+  if (Config::Get().only_show_first_popup && ShouldSuppressAdditionalPopup()) {
+    spdlog::debug("ShopSceneManager_ShowPlcOfferPopup: suppressing PLC offer popup (already shown one)");
     return;
   }
   original(_this);

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -187,12 +187,11 @@ public:
 
 void InterstitialViewController_AboutToShow(auto original, InterstitialViewController* _this)
 {
-  if (Config::Get().disable_first_popup && _this != nullptr) {
+  if (Config::Get().disable_first_popup) {
     spdlog::debug("InterstitialViewController_AboutToShow: suppressing interstitial popup");
-    _this->CloseWhenReady();
-  } else {
-    original(_this);
+    return;
   }
+  original(_this);
 }
 
 void ShopSceneManager_ShowPlcOfferPopup(auto original, void* _this)

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -185,16 +185,45 @@ public:
   }
 };
 
-bool isFirstInterstitial = true;
-
 void InterstitialViewController_AboutToShow(auto original, InterstitialViewController* _this)
 {
-  if (false /* TEMP: disable_first_popup effect disabled */ && Config::Get().disable_first_popup
-      && isFirstInterstitial && _this != nullptr) {
-    isFirstInterstitial = false;
+  if (Config::Get().disable_first_popup && _this != nullptr) {
+    spdlog::debug("InterstitialViewController_AboutToShow: suppressing interstitial popup");
     _this->CloseWhenReady();
   } else {
     original(_this);
+  }
+}
+
+void ShopSceneManager_ShowPlcOfferPopup(auto original, void* _this)
+{
+  if (Config::Get().disable_first_popup) {
+    spdlog::debug("ShopSceneManager_ShowPlcOfferPopup: suppressing PLC offer popup");
+    return;
+  }
+  original(_this);
+}
+
+bool LoginStreakManager_TryShowStreakPopupForGameSessionStarted(auto original, void* _this)
+{
+  if (Config::Get().disable_first_popup) {
+    spdlog::debug("LoginStreakManager_TryShowStreakPopupForGameSessionStarted: suppressing login streak popup");
+    return false;
+  }
+  return original(_this);
+}
+
+void TutorialManager_ShowTutorialScreen(auto original, void* _this)
+{
+  if (!Config::Get().disable_tutorials) {
+    original(_this);
+  }
+}
+
+void TutorialManager_ShowTutorialScreen_2(auto original, void* _this, void* tutorialComponent, void* tutorialStep)
+{
+  if (!Config::Get().disable_tutorials) {
+    original(_this, tutorialComponent, tutorialStep);
   }
 }
 
@@ -243,6 +272,51 @@ void InstallTempCrashFixes()
       ErrorMsg::MissingMethod("InterstitialViewController", "AboutToShow");
     } else {
       SPUD_STATIC_DETOUR(interstitial_show, InterstitialViewController_AboutToShow);
+    }
+  }
+
+  static auto shop_scene_manager_cls =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Shop", "ShopSceneManager");
+  if (!shop_scene_manager_cls.isValidHelper()) {
+    ErrorMsg::MissingHelper("Shop", "ShopSceneManager");
+  } else {
+    auto show_plc = shop_scene_manager_cls.GetMethod("ShowPlcOfferPopup", 0);
+    if (!show_plc) {
+      ErrorMsg::MissingMethod("ShopSceneManager", "ShowPlcOfferPopup");
+    } else {
+      SPUD_STATIC_DETOUR(show_plc, ShopSceneManager_ShowPlcOfferPopup);
+    }
+  }
+
+  static auto login_streak_manager =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.LoginStreak", "LoginStreakManager");
+  if (!login_streak_manager.isValidHelper()) {
+    ErrorMsg::MissingHelper("LoginStreak", "LoginStreakManager");
+  } else {
+    auto show_streak = login_streak_manager.GetMethod("TryShowStreakPopupForGameSessionStarted", 0);
+    if (!show_streak) {
+      ErrorMsg::MissingMethod("LoginStreakManager", "TryShowStreakPopupForGameSessionStarted");
+    } else {
+      SPUD_STATIC_DETOUR(show_streak, LoginStreakManager_TryShowStreakPopupForGameSessionStarted);
+    }
+  }
+
+  static auto tutorial_manager =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Tutorial", "TutorialManager");
+  if (!tutorial_manager.isValidHelper()) {
+    ErrorMsg::MissingHelper("Tutorial", "TutorialManager");
+  } else {
+    auto show_tutorial_screen = tutorial_manager.GetMethod("ShowTutorialScreen", 0);
+    if (!show_tutorial_screen) {
+      ErrorMsg::MissingMethod("TutorialManager", "ShowTutorialScreen");
+    } else {
+      SPUD_STATIC_DETOUR(show_tutorial_screen, TutorialManager_ShowTutorialScreen);
+    }
+    auto show_tutorial_screen_2 = tutorial_manager.GetMethod("ShowTutorialScreen", 2);
+    if (!show_tutorial_screen_2) {
+      ErrorMsg::MissingMethod("TutorialManager", "ShowTutorialScreen(2)");
+    } else {
+      SPUD_STATIC_DETOUR(show_tutorial_screen_2, TutorialManager_ShowTutorialScreen_2);
     }
   }
 


### PR DESCRIPTION
## Fix `disable_first_popup` interstitial suppression and add store offer popup suppression

### Background

The `disable_first_popup` setting was added in PR #37 to suppress the first ad/interstitial popup. It was disabled in PR #139 with the message "temporarily ignore the disable_first_popup option, as it does not work" and hardcoded to `if (false ...)`. The feature has been dead code on `dev` since.

### Why the original approach didn't work

The original hook intercepted `InterstitialViewController.AboutToShow` and called `CloseWhenReady()` **instead of** calling `original()`:

```cpp
if (Config::Get().disable_first_popup && isFirstInterstitial && _this != nullptr) {
    isFirstInterstitial = false;
    _this->CloseWhenReady();   // <-- called WITHOUT original() first
} else {
    original(_this);
}
```

### How this PR fixes it

The hook now **calls `original()` first** to let the popup initialize properly, then immediately closes it:

```cpp
void InterstitialViewController_AboutToShow(auto original, InterstitialViewController* _this)
{
  original(_this);
  if (Config::Get().disable_first_popup && _this != nullptr) {
    spdlog::debug("InterstitialViewController_AboutToShow: suppressing interstitial popup");
    _this->CloseWhenReady();
  }
}
```

- `original()` runs unconditionally → the view controller goes through its full initialization lifecycle, no empty screen, no unready-state crash.
- `CloseWhenReady()` runs **after** initialization → closes the popup immediately after it appears, so the user never sees it.
- The `isFirstInterstitial` one-shot flag is removed → suppression applies to **all** interstitials, not just the first.

### Additional changes

- **Store offer popup suppression** — new hook on `ShopSceneManager.ShowPlcOfferPopup` that drops the call when `disable_first_popup` is enabled. This popup type doesn't require lifecycle initialization, so skipping the call entirely is safe.
- **Consolidated `ShopSceneManager` lookup** — the class was being resolved twice; now resolved once as `static`.
- **Updated example config comments** (en, de, fr, nl) — `disable_first_popup` comment changed from "Prevent the first popup advert" to "Prevent ad/interstitial popups from appearing" to reflect that it now suppresses all such popups, not just the first.

### How to verify

1. With `disable_first_popup = false` (default) — all popups appear as before.
2. Set `disable_first_popup = true`, restart:
   - Ad/interstitial popups should close immediately (look for `InterstitialViewController_AboutToShow: suppressing interstitial popup` in debug logs).
   - Store pack offers should not appear at all (look for `ShopSceneManager_ShowPlcOfferPopup: suppressing PLC offer popup`).

### Risks

- **`CloseWhenReady()` is still called on every interstitial** — while calling it _after_ `original()` avoids the uninitialized-state crash, it has not been runtime-verified against all popup types. The setting is still marked `⚠️ EXPERIMENTAL` in the config and defaults to `false`.
- **`disable_first_popup` semantics broadened** — the setting previously (when it worked) only suppressed the first interstitial; it now suppresses all interstitials and store offers. The config comment has been updated accordingly.