### PR TITLE
Add ability to suppress certain audio

### DIFF
--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -19,6 +19,7 @@
 #include <string_view>
 
 namespace DCP  = DefaultConfig::Patches;
+namespace DCA  = DefaultConfig::Audio;
 namespace DCG  = DefaultConfig::Graphics;
 namespace DCC  = DefaultConfig::Control;
 namespace DCU  = DefaultConfig::UI;
@@ -892,6 +893,18 @@ void Config::Load()
       get_config_or_default(config, parsed, "ui", "disable_move_keys", DCU::disable_move_keys, write_config);
   this->disable_toast_banners =
       get_config_or_default(config, parsed, "ui", "disable_toast_banners", DCU::disable_toast_banners, write_config);
+  this->trace_audio_events =
+      get_config_or_default(config, parsed, "audio", "trace_events", DCA::trace_events, write_config);
+  auto disabled_audio_events = get_config_or_default<std::string>(
+      config, parsed, "audio", "disabled_events", DCA::disabled_events, write_config);
+  this->disabled_audio_events.clear();
+  for (const auto& event : StrSplit(disabled_audio_events, ',')) {
+    auto stripped = StripAsciiWhitespace(event);
+    if (!stripped.empty()) {
+      this->disabled_audio_events.emplace_back(stripped);
+    }
+  }
+  this->installAudioEventHooks = this->trace_audio_events || !this->disabled_audio_events.empty();
   this->auto_open_bulk_claim_flyout = get_config_or_default(config, parsed, "ui", "auto_open_bulk_claim_flyout",
                                                             DCU::auto_open_bulk_claim_flyout, write_config);
   this->auto_confirm_instant_warp =

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -194,6 +194,8 @@ public:
   bool disable_veil_chat;
   bool disable_first_popup;
   bool disable_toast_banners;
+  bool trace_audio_events;
+  std::vector<std::string> disabled_audio_events;
   bool auto_open_bulk_claim_flyout;
   bool auto_confirm_ft_upgrade;
 
@@ -240,6 +242,7 @@ public:
   bool installObjectTracker;
   bool installGiftsBulkClaimHooks;
   bool installInstantWarpConfirmationHooks;
+  bool installAudioEventHooks;
 
   std::string config_settings_url;
   std::string config_assets_url_override;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -7,6 +7,12 @@ namespace Buffs
   constexpr bool use_out_of_dock_power = true;
 } // namespace Buffs
 
+namespace Audio
+{
+  constexpr const char* disabled_events = "";
+  constexpr bool        trace_events    = false;
+} // namespace Audio
+
 namespace SystemConfig
 {
   constexpr const char* assets_url_override = "";

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -44,6 +44,7 @@ void InstallCargoFormatHooks();
 void InstallOfficerSortHooks();
 void InstallInstantWarpConfirmationHooks();
 void InstallForbiddenTechConfirmationHooks();
+void InstallAudioEventHooks();
 
 __int64 il2cpp_init_hook(auto original, const char* domain_name)
 {
@@ -142,6 +143,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"OfficerSortHooks",     {InstallOfficerSortHooks,      &cfg.installOfficerSortHooks}},
       {"InstantWarpConfirm",   {InstallInstantWarpConfirmationHooks, &cfg.installInstantWarpConfirmationHooks}},
       {"ForbiddenTechConfirm", {InstallForbiddenTechConfirmationHooks, &cfg.auto_confirm_ft_upgrade}},
+      {"AudioEvents",          {InstallAudioEventHooks,                 &cfg.installAudioEventHooks}},
   };
   printf("il2cpp_init_hook(%s)\n", domain_name);
 


### PR DESCRIPTION
This PR adds the ability to suppress audio events.  Because they are named such as:

```
 Music_All
 UI/Button/Primary/OnClick
 UI/HUD/FleetbarPanel_SelectFleet
 UI/Navigation/BattleCue_Enter
 UI/Navigation/Engage
 UI/Navigation/ReticleSmall
 UI/Navigation/Reticule_TapEnnemy
 UI/Navigation/TapEmptySpace
 UI/Navigation/TapSpaceObject
 UI/Toast/Neutral
 UI/Toast/Victory
```
(**Note:** _Not a complete list_)

Also adds option to also enable audio auditing and see what events are being played.  

List can be multiple entries comma separated.
