### PR TITLE
Feature/improve ship management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ debug.log
 mods/.xmake
 Analyse-GameAssembly.ps1
 assets/LoadingScreens/*.psd
-
-
-/dump.cs

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ debug.log
 mods/.xmake
 Analyse-GameAssembly.ps1
 assets/LoadingScreens/*.psd
+
+
+/dump.cs

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -584,8 +584,9 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
-# Schiffe, die im Flottenmanagement-Dock immer zuerst angezeigt werden, unabhängig von der aktiven Sortierung.
-# Durch Kommas getrennte Schiffsnamen. Die Reihenfolge bestimmt die Anheftungspriorität.
+# Schiffe, die im Flottenmanagement-Dock immer zuerst angezeigt werden. Angeheftete Schiffe behalten
+# untereinander die Reihenfolge der aktiven Sortierung; durch Kommas getrennte Schiffsnamen,
+# die Listenreihenfolge spielt keine Rolle.
 # Beispiel: pinned_ships = "USS Vengeance, GS-31, Discovery"
 pinned_ships = ""
 

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -645,6 +645,10 @@ pinned_ships = ""
 # und dann auf "Zuweisen" zu klicken
 double_click_to_assign_ship = false
 
+# Mit den Pfeiltasten links/rechts das vorherige/nächste Schiff im
+# Flottenmanagement-Dock auswählen
+arrow_keys_to_select_ship = true
+
 # Subgroup: HUD
 # -------------
 

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -584,6 +584,11 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
+# Schiffe, die im Flottenmanagement-Dock immer zuerst angezeigt werden, unabhängig von der aktiven Sortierung.
+# Durch Kommas getrennte Schiffsnamen. Die Reihenfolge bestimmt die Anheftungspriorität.
+# Beispiel: pinned_ships = "USS Vengeance, GS-31, Discovery"
+pinned_ships = ""
+
 # Stufen- und Rangverbesserungen für Verbotene Technologie automatisch bestätigen
 auto_confirm_ft_upgrade = false
 

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -584,12 +584,6 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
-# Schiffe, die im Flottenmanagement-Dock immer zuerst angezeigt werden. Angeheftete Schiffe behalten
-# untereinander die Reihenfolge der aktiven Sortierung; durch Kommas getrennte Schiffsnamen,
-# die Listenreihenfolge spielt keine Rolle.
-# Beispiel: pinned_ships = "USS Vengeance, GS-31, Discovery"
-pinned_ships = ""
-
 # Stufen- und Rangverbesserungen für Verbotene Technologie automatisch bestätigen
 auto_confirm_ft_upgrade = false
 
@@ -637,6 +631,19 @@ extend_donation_max = 80
 
 # Erweiterung des Spendenschiebereglers aktivieren
 extend_donation_slider = true
+
+# Subgroup: Fleet Management
+# --------------------------
+
+# Schiffe, die im Flottenmanagement-Dock immer zuerst angezeigt werden. Angeheftete Schiffe behalten
+# untereinander die Reihenfolge der aktiven Sortierung; durch Kommas getrennte Schiffsnamen,
+# die Listenreihenfolge spielt keine Rolle.
+# Beispiel: pinned_ships = "USS Vengeance, GS-31, Discovery"
+pinned_ships = ""
+
+# Ein Schiff im Flottenmanagement-Dock per Doppelklick zuweisen, statt es auszuwählen
+# und dann auf "Zuweisen" zu klicken
+double_click_to_assign_ship = false
 
 # Subgroup: HUD
 # -------------

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -584,6 +584,11 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
+# Ships to always show first in the fleet management dock, regardless of the active sort.
+# Comma-separated ship names. Order determines pin priority.
+# Example: pinned_ships = "USS Vengeance, GS-31, Discovery"
+pinned_ships = ""
+
 # Confirm Forbidden Tech level and tier upgrades automatically
 auto_confirm_ft_upgrade = false
 

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -584,8 +584,8 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
-# Ships to always show first in the fleet management dock, regardless of the active sort.
-# Comma-separated ship names. Order determines pin priority.
+# Ships to always show first in the fleet management dock. Pinned ships keep the active sort's
+# order among themselves; comma-separated ship names, list order doesn't matter.
 # Example: pinned_ships = "USS Vengeance, GS-31, Discovery"
 pinned_ships = ""
 

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -645,6 +645,10 @@ pinned_ships = ""
 # selecting then clicking Assign
 double_click_to_assign_ship = false
 
+# Use the Left/Right arrow keys to select the previous/next ship in the
+# fleet management dock
+arrow_keys_to_select_ship = true
+
 # Subgroup: HUD
 # -------------
 

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -584,11 +584,6 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
-# Ships to always show first in the fleet management dock. Pinned ships keep the active sort's
-# order among themselves; comma-separated ship names, list order doesn't matter.
-# Example: pinned_ships = "USS Vengeance, GS-31, Discovery"
-pinned_ships = ""
-
 # Confirm Forbidden Tech level and tier upgrades automatically
 auto_confirm_ft_upgrade = false
 
@@ -636,6 +631,19 @@ extend_donation_max = 80
 
 # Extend donation slider enable
 extend_donation_slider = true
+
+# Subgroup: Fleet Management
+# --------------------------
+
+# Ships to always show first in the fleet management dock. Pinned ships keep
+# the active sort's order among themselves; comma-separated ship names,
+# list order doesn't matter.
+# Example: pinned_ships = "USS Vengeance, GS-31, Discovery"
+pinned_ships = ""
+
+# Double-click a ship in the fleet management dock to assign it, instead of
+# selecting then clicking Assign
+double_click_to_assign_ship = false
 
 # Subgroup: HUD
 # -------------

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -584,6 +584,11 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
+# Vaisseaux à toujours afficher en premier dans le dock de gestion de flotte, quel que soit le tri actif.
+# Noms de vaisseaux séparés par des virgules. L'ordre détermine la priorité d'épinglage.
+# Exemple : pinned_ships = "USS Vengeance, GS-31, Discovery"
+pinned_ships = ""
+
 # Confirmer automatiquement les améliorations de niveau et de rang de Technologie interdite
 auto_confirm_ft_upgrade = false
 

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -584,8 +584,9 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
-# Vaisseaux à toujours afficher en premier dans le dock de gestion de flotte, quel que soit le tri actif.
-# Noms de vaisseaux séparés par des virgules. L'ordre détermine la priorité d'épinglage.
+# Vaisseaux à toujours afficher en premier dans le dock de gestion de flotte. Les vaisseaux épinglés
+# conservent l'ordre du tri actif entre eux ; noms séparés par des virgules, l'ordre de la liste
+# n'a pas d'importance.
 # Exemple : pinned_ships = "USS Vengeance, GS-31, Discovery"
 pinned_ships = ""
 

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -645,6 +645,10 @@ pinned_ships = ""
 # le sélectionner puis de cliquer sur Assigner
 double_click_to_assign_ship = false
 
+# Utiliser les flèches gauche/droite pour sélectionner le vaisseau précédent/suivant
+# dans le dock de gestion de flotte
+arrow_keys_to_select_ship = true
+
 # Subgroup: HUD
 # -------------
 

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -584,12 +584,6 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
-# Vaisseaux à toujours afficher en premier dans le dock de gestion de flotte. Les vaisseaux épinglés
-# conservent l'ordre du tri actif entre eux ; noms séparés par des virgules, l'ordre de la liste
-# n'a pas d'importance.
-# Exemple : pinned_ships = "USS Vengeance, GS-31, Discovery"
-pinned_ships = ""
-
 # Confirmer automatiquement les améliorations de niveau et de rang de Technologie interdite
 auto_confirm_ft_upgrade = false
 
@@ -637,6 +631,19 @@ extend_donation_max = 80
 
 # Activer l'extension du curseur de don
 extend_donation_slider = true
+
+# Subgroup: Fleet Management
+# --------------------------
+
+# Vaisseaux à toujours afficher en premier dans le dock de gestion de flotte. Les vaisseaux épinglés
+# conservent l'ordre du tri actif entre eux ; noms séparés par des virgules, l'ordre de la liste
+# n'a pas d'importance.
+# Exemple : pinned_ships = "USS Vengeance, GS-31, Discovery"
+pinned_ships = ""
+
+# Double-cliquer sur un vaisseau dans le dock de gestion de flotte pour l'assigner, au lieu de
+# le sélectionner puis de cliquer sur Assigner
+double_click_to_assign_ship = false
 
 # Subgroup: HUD
 # -------------

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -584,12 +584,6 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
-# Schepen die altijd eerst worden getoond in het vlootbeheerdok. Vastgezette schepen behouden
-# onderling de volgorde van de actieve sortering; door komma's gescheiden scheepsnamen,
-# de volgorde in de lijst maakt niet uit.
-# Voorbeeld: pinned_ships = "USS Vengeance, GS-31, Discovery"
-pinned_ships = ""
-
 # Level- en rangupgrades voor Verboden Technologie automatisch bevestigen
 auto_confirm_ft_upgrade = false
 
@@ -637,6 +631,19 @@ extend_donation_max = 80
 
 # Zet dit aan als je de schuifregelaar voor alliantie donaties wilt uitbreiden
 extend_donation_slider = true
+
+# Subgroup: Fleet Management
+# --------------------------
+
+# Schepen die altijd eerst worden getoond in het vlootbeheerdok. Vastgezette schepen behouden
+# onderling de volgorde van de actieve sortering; door komma's gescheiden scheepsnamen,
+# de volgorde in de lijst maakt niet uit.
+# Voorbeeld: pinned_ships = "USS Vengeance, GS-31, Discovery"
+pinned_ships = ""
+
+# Dubbelklik op een schip in het vlootbeheerdok om het toe te wijzen, in plaats van eerst te
+# selecteren en dan op Toewijzen te klikken
+double_click_to_assign_ship = false
 
 # Subgroup: HUD
 # -------------

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -584,6 +584,11 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
+# Schepen die altijd eerst worden getoond in het vlootbeheerdok, ongeacht de actieve sortering.
+# Door komma's gescheiden scheepsnamen. De volgorde bepaalt de vastzetprioriteit.
+# Voorbeeld: pinned_ships = "USS Vengeance, GS-31, Discovery"
+pinned_ships = ""
+
 # Level- en rangupgrades voor Verboden Technologie automatisch bevestigen
 auto_confirm_ft_upgrade = false
 

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -584,8 +584,9 @@ disable_toast_banners = false
 # Subgroup: Auto Confirm
 # ----------------------
 
-# Schepen die altijd eerst worden getoond in het vlootbeheerdok, ongeacht de actieve sortering.
-# Door komma's gescheiden scheepsnamen. De volgorde bepaalt de vastzetprioriteit.
+# Schepen die altijd eerst worden getoond in het vlootbeheerdok. Vastgezette schepen behouden
+# onderling de volgorde van de actieve sortering; door komma's gescheiden scheepsnamen,
+# de volgorde in de lijst maakt niet uit.
 # Voorbeeld: pinned_ships = "USS Vengeance, GS-31, Discovery"
 pinned_ships = ""
 

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -645,6 +645,10 @@ pinned_ships = ""
 # selecteren en dan op Toewijzen te klikken
 double_click_to_assign_ship = false
 
+# Gebruik de pijltjestoetsen links/rechts om het vorige/volgende schip in het
+# vlootbeheerdok te selecteren
+arrow_keys_to_select_ship = true
+
 # Subgroup: HUD
 # -------------
 

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -2,6 +2,7 @@
 #include "file.h"
 #include "patches/mapkey.h"
 #include "prime/KeyCode.h"
+#include "ship_name_match.h"
 #include "str_utils.h"
 #include "version.h"
 #include <prime/Toast.h>
@@ -432,8 +433,9 @@ void parse_ship_filter(std::string_view value, std::vector<std::string>& names, 
   for (const auto& token : StrSplit(std::string(value), ',')) {
     auto stripped = StripAsciiWhitespace(token);
     if (stripped.empty()) continue;
-    auto normalized = AsciiStrToUpper(stripped);
-    names.emplace_back(normalized);
+    if (auto normalized = ShipNameMatch::NormalizeKey(stripped); !normalized.empty()) {
+      names.emplace_back(std::move(normalized));
+    }
   }
 }
 
@@ -812,6 +814,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "patches", "cargoformathooks", DCP::cargoformathooks, write_config);
   this->installOfficerSortHooks =
       get_config_or_default(config, parsed, "patches", "officersorthooks", DCP::officersorthooks, write_config);
+  this->installPinnedShipSortHooks =
+      get_config_or_default(config, parsed, "patches", "pinnedshiphooks", DCP::pinnedshiphooks, write_config);
   spdlog::debug("");
   this->queue_enabled =
       get_config_or_default(config, parsed, "control", "queue_enabled", DCC::queue_enabled, write_config);
@@ -916,6 +920,12 @@ void Config::Load()
                            this->instant_warp_auto_warp_all, DCU::instant_warp_auto_warp, write_config);
   read_instant_warp_filter(config, parsed, "instant_warp_always_ask", this->instant_warp_always_ask,
                            this->instant_warp_always_ask_all, DCU::instant_warp_always_ask, write_config);
+
+  {
+    bool unused_match_all = false;
+    read_instant_warp_filter(config, parsed, "pinned_ships", this->pinned_ships, unused_match_all,
+                             DCU::pinned_ships, write_config);
+  }
 
   this->auto_confirm_ft_upgrade =
       get_config_or_default(config, parsed, "ui", "auto_confirm_ft_upgrade",

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -927,6 +927,9 @@ void Config::Load()
                              DCU::pinned_ships, write_config);
   }
 
+  this->double_click_to_assign_ship = get_config_or_default(config, parsed, "ui", "double_click_to_assign_ship",
+                                                             DCU::double_click_to_assign_ship, write_config);
+
   this->auto_confirm_ft_upgrade =
       get_config_or_default(config, parsed, "ui", "auto_confirm_ft_upgrade",
                             DCU::auto_confirm_ft_upgrade, write_config);

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -930,6 +930,9 @@ void Config::Load()
   this->double_click_to_assign_ship = get_config_or_default(config, parsed, "ui", "double_click_to_assign_ship",
                                                              DCU::double_click_to_assign_ship, write_config);
 
+  this->arrow_keys_to_select_ship = get_config_or_default(config, parsed, "ui", "arrow_keys_to_select_ship",
+                                                           DCU::arrow_keys_to_select_ship, write_config);
+
   this->auto_confirm_ft_upgrade =
       get_config_or_default(config, parsed, "ui", "auto_confirm_ft_upgrade",
                             DCU::auto_confirm_ft_upgrade, write_config);

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -212,6 +212,7 @@ public:
   std::vector<std::string> pinned_ships;
 
   bool double_click_to_assign_ship;
+  bool arrow_keys_to_select_ship;
 
   bool show_cargo_default;
   bool show_player_cargo;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -211,6 +211,8 @@ public:
 
   std::vector<std::string> pinned_ships;
 
+  bool double_click_to_assign_ship;
+
   bool show_cargo_default;
   bool show_player_cargo;
   bool show_station_cargo;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -209,6 +209,8 @@ public:
   std::vector<std::string> instant_warp_always_ask;
   bool                     instant_warp_always_ask_all = false;
 
+  std::vector<std::string> pinned_ships;
+
   bool show_cargo_default;
   bool show_player_cargo;
   bool show_station_cargo;
@@ -265,4 +267,7 @@ public:
 
   // Officer roster/assignment "Below Deck Ability" sort option restore
   bool installOfficerSortHooks;
+
+  // Fleet management dock ship sort: pin configured ships to the front
+  bool installPinnedShipSortHooks;
 };

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -85,6 +85,7 @@ namespace Patches
   constexpr bool focussearch                = true;
   constexpr bool cargoformathooks           = true;  // on by default: cargo number precision override
   constexpr bool officersorthooks           = true;  // restore Below Deck Ability sort option
+  constexpr bool pinnedshiphooks            = true;  // pin configured ships to front of fleet dock sort
 } // namespace Patches
 
 namespace Shortcuts
@@ -234,6 +235,7 @@ namespace UI
   constexpr const char* instant_warp_auto_jump     = "";
   constexpr const char* instant_warp_auto_warp     = "";
   constexpr const char* instant_warp_always_ask    = "";
+  constexpr const char* pinned_ships                = "";
   constexpr const char* notify_banner_types         = "";
   constexpr auto        extend_chest_purchase_max   = 160;
   constexpr auto        extend_donation_max         = 80;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -225,6 +225,7 @@ namespace UI
   constexpr bool        disable_preview_recall      = false;
   constexpr bool        disable_toast_banners       = false;
   constexpr bool        disable_veil_chat           = false;
+  constexpr bool        double_click_to_assign_ship = false;
   constexpr const char* disabled_banner_types       = "";
   constexpr const char* hud_daily_goals             = "auto";
   constexpr const char* hud_field_training          = "auto";

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -214,6 +214,7 @@ namespace Sync
 namespace UI
 {
   constexpr bool        always_skip_reveal_sequence = true;
+  constexpr bool        arrow_keys_to_select_ship   = true;
   constexpr bool        auto_confirm_discovery      = true;
   constexpr bool        auto_confirm_ft_upgrade     = false;
   constexpr bool        auto_open_bulk_claim_flyout = false;

--- a/mods/src/patches/parts/double_click_assign_ship.cc
+++ b/mods/src/patches/parts/double_click_assign_ship.cc
@@ -1,0 +1,83 @@
+#include "config.h"
+#include "errormsg.h"
+
+#include "prime/AssignShipsWidget.h"
+#include "prime/CanvasController.h"
+#include "prime/ShipTileWidget.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <spud/detour.h>
+
+#include <chrono>
+
+// Ship-assignment dock: double-clicking a ship tile presses the Assign
+// button, instead of requiring select-then-click-Assign. Detected by timing
+// since Unity's Button.onClick doesn't report click count; keyed off the
+// tile's bound FleetPlayerData context so reused/pooled list rows don't
+// misfire across different ships.
+
+namespace {
+
+constexpr auto kDoubleClickWindow = std::chrono::milliseconds(400);
+
+FleetPlayerData*                      g_last_clicked_ship = nullptr;
+std::chrono::steady_clock::time_point g_last_click_time{};
+
+void PressAssignButton()
+{
+  for (auto widget : ObjectFinder<AssignShipsWidget>::GetAll()) {
+    if (!widget) continue;
+
+    auto canvas = GetCanvasControllerFromComponent(widget);
+    if (!canvas || !canvas->Visible() || !widget->isActiveAndEnabled) continue;
+
+    auto* buttonWrapper = widget->_assignButton;
+    auto* buttonWidget  = buttonWrapper ? buttonWrapper->Widget : nullptr;
+    auto* listener      = buttonWidget ? buttonWidget->SemaphoreListener : nullptr;
+    auto* button        = listener ? listener->TheButton : nullptr;
+    if (button) {
+      button->Press();
+    }
+    return;
+  }
+}
+
+void ShipTileWidget_HandleOnClick_Hook(auto original, ShipTileWidget* _this)
+{
+  original(_this);
+
+  if (!Config::Get().double_click_to_assign_ship) return;
+
+  auto* ship = _this ? _this->Context : nullptr;
+  if (!ship) return;
+
+  const auto now             = std::chrono::steady_clock::now();
+  const bool is_double_click = ship == g_last_clicked_ship && (now - g_last_click_time) <= kDoubleClickWindow;
+
+  g_last_clicked_ship = ship;
+  g_last_click_time   = now;
+
+  if (!is_double_click) return;
+
+  g_last_clicked_ship = nullptr; // consume, so a triple/quadruple click doesn't re-trigger immediately
+  PressAssignButton();
+}
+
+} // namespace
+
+void InstallDoubleClickAssignShipHooks()
+{
+  auto helper = ShipTileWidget::get_class_helper();
+  if (!helper.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.Prime.Ships", "ShipTileWidget");
+    return;
+  }
+
+  auto method = helper.GetMethod("HandleOnClick", 0);
+  if (!method) {
+    ErrorMsg::MissingMethod("ShipTileWidget", "HandleOnClick");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(method, ShipTileWidget_HandleOnClick_Hook);
+}

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -15,7 +15,9 @@
 #include "prime/ActionQueueManager.h"
 #include "prime/AnimatedRewardsScreenViewController.h"
 #include "prime/ArtifactHallDetailsViewController.h"
+#include "prime/AssignShipsWidget.h"
 #include "prime/BookmarksManager.h"
+#include "prime/CanvasController.h"
 #include "prime/ChatManager.h"
 #include "prime/DeploymentManager.h"
 #include "prime/ElementSelectorViewController.h"
@@ -31,6 +33,7 @@
 #include "prime/PreScanTargetWidget.h"
 #include "prime/ScanEngageButtonsWidget.h"
 #include "prime/ScreenManager.h"
+#include "prime/SelectableList.h"
 
 #include "patches/key.h"
 #include "patches/mapkey.h"
@@ -114,6 +117,7 @@ bool MoveArtifactCanvas(bool goLeft)
 
     if (!controller->isActiveAndEnabled()) {
       spdlog::trace("MoveArtifactCanvas({}) - Controller not active", (int)goLeft);
+      continue;
     }
 
     if (goLeft) {
@@ -124,6 +128,58 @@ bool MoveArtifactCanvas(bool goLeft)
       controller->PressRightArrow();
     }
     acted = true;
+  }
+
+  return acted;
+}
+
+bool IsRealShipIndex(SelectableList* list, int32_t index)
+{
+  auto* item = list->DataItem(index);
+  if (!item) return false;
+  return reinterpret_cast<FleetPlayerData*>(item)->HasShip;
+}
+
+bool MoveShipSelectionInDock(bool goLeft)
+{
+  if (!Config::Get().arrow_keys_to_select_ship) {
+    return false;
+  }
+
+  bool acted = false;
+  for (auto widget : ObjectFinder<AssignShipsWidget>::GetAll()) {
+    if (!widget) continue;
+
+    auto canvas = GetCanvasControllerFromComponent(widget);
+    if (!canvas || !canvas->Visible() || !widget->isActiveAndEnabled) {
+      spdlog::trace("MoveShipSelectionInDock({}) - widget={} not visible/active", (int)goLeft, (void*)widget);
+      continue;
+    }
+
+    auto* list = widget->_selectableList;
+    if (!list) {
+      spdlog::trace("MoveShipSelectionInDock({}) - widget={} has no _selectableList", (int)goLeft, (void*)widget);
+      continue;
+    }
+
+    const auto count = list->Count;
+    if (count <= 0) {
+      spdlog::trace("MoveShipSelectionInDock({}) - list={} count={}", (int)goLeft, (void*)list, count);
+      continue;
+    }
+
+    const auto step = goLeft ? -1 : 1;
+    auto       newIndex = list->SelectedIndex + step;
+    while (newIndex >= 0 && newIndex < count && !IsRealShipIndex(list, newIndex)) {
+      newIndex += step;
+    }
+    if (newIndex < 0 || newIndex >= count) {
+      spdlog::trace("MoveShipSelectionInDock({}) - no further real ship in that direction", (int)goLeft);
+      continue;
+    }
+
+    spdlog::debug("MoveShipSelectionInDock({}) - selecting index {} of {}", (int)goLeft, newIndex, count);
+    acted = list->RequestSelect(newIndex) || acted;
   }
 
   return acted;
@@ -300,14 +356,14 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
       }
 
       if (MapKey::IsDown(GameFunction::MoveLeft)) {
-        auto const result = MoveArtifactCanvas(true) || MoveOfficerCanvas(true);
+        auto const result = MoveShipSelectionInDock(true) || MoveArtifactCanvas(true) || MoveOfficerCanvas(true);
         if (result) {
           return;
         }
       }
 
       if (MapKey::IsDown(GameFunction::MoveRight)) {
-        auto const result = MoveArtifactCanvas(false) || MoveOfficerCanvas(false);
+        auto const result = MoveShipSelectionInDock(false) || MoveArtifactCanvas(false) || MoveOfficerCanvas(false);
         if (result) {
           return;
         }

--- a/mods/src/patches/parts/instant_warp_confirmation.cc
+++ b/mods/src/patches/parts/instant_warp_confirmation.cc
@@ -34,7 +34,8 @@ void CoursePromptPopupViewController_AboutToShow_Hook(auto original, CoursePromp
     fleet = course->PlayerFleet;
   }
 
-  const auto candidates = ShipNameMatch::CandidateWords(fleet);
+  std::string hull_name;
+  const auto  candidates = ShipNameMatch::CandidateWords(fleet, &hull_name);
 
   const auto matches = [&candidates](const std::vector<std::string>& names, bool all) -> bool {
     if (all) return true;

--- a/mods/src/patches/parts/instant_warp_confirmation.cc
+++ b/mods/src/patches/parts/instant_warp_confirmation.cc
@@ -1,6 +1,6 @@
 #include "config.h"
 #include "errormsg.h"
-#include "str_utils.h"
+#include "ship_name_match.h"
 
 #include <prime/CourseData.h>
 #include <prime/CoursePromptPopupWidget.h>
@@ -29,22 +29,19 @@ void CoursePromptPopupViewController_AboutToShow_Hook(auto original, CoursePromp
 
   const auto& cfg = Config::Get();
 
-  std::string hull_name;
+  FleetPlayerData* fleet = nullptr;
   if (const auto course = context->GetCourseData(); course != nullptr) {
-    if (const auto fleet = course->PlayerFleet; fleet != nullptr) {
-      if (const auto hull = fleet->Hull; hull != nullptr) {
-        if (const auto name = hull->Name; name != nullptr) {
-          hull_name = AsciiStrToUpper(to_string(name));
-          hull_name = StripSuffix(hull_name, "_LIVE");
-        }
-      }
-    }
+    fleet = course->PlayerFleet;
   }
 
-  const auto matches = [&hull_name](const std::vector<std::string>& names, bool all) -> bool {
+  const auto candidates = ShipNameMatch::CandidateWords(fleet);
+
+  const auto matches = [&candidates](const std::vector<std::string>& names, bool all) -> bool {
     if (all) return true;
-    if (hull_name.empty()) return false;
-    return std::ranges::any_of(names, [&](const auto& s) { return s == hull_name; });
+    if (candidates.empty()) return false;
+    return std::ranges::any_of(names, [&](const auto& configured) {
+      return ShipNameMatch::MatchesAny(candidates, ShipNameMatch::SplitWords(configured));
+    });
   };
 
   if (matches(cfg.instant_warp_always_ask, cfg.instant_warp_always_ask_all)) {

--- a/mods/src/patches/parts/pinned_ship_sort.cc
+++ b/mods/src/patches/parts/pinned_ship_sort.cc
@@ -17,10 +17,11 @@
 
 // Fleet management dock ship sort: hooks ShipManagementViewContext.Sort()
 // and stable-partitions cfg.pinned_ships to the front of SortedIdleShips,
-// keeping everyone else in their existing order. Only the concrete class is
-// hooked, not ISortedFleetsContext, so HailingFrequenciesInventoryContext is
-// unaffected. Matching is shared with the instant-warp filters (ship_name_match.h).
-// If multiple ships share a pinned name, only the highest-level unclaimed one is pinned.
+// keeping the active sort field's order within both the pinned group and
+// everyone else. Only the concrete class is hooked, not ISortedFleetsContext,
+// so HailingFrequenciesInventoryContext is unaffected. Matching is shared
+// with the instant-warp filters (ship_name_match.h). If multiple ships share
+// a pinned name, only the highest-level unclaimed one is pinned.
 
 namespace {
 
@@ -78,8 +79,8 @@ ShipEntry BuildShipEntry(void* item)
 }
 
 // Stable-partitions `list` (a List<FleetPlayerData>) so that ships matching
-// cfg.pinned_ships come first, ordered by their position in that config list,
-// while every other ship keeps its existing relative order.
+// cfg.pinned_ships come first, while both the pinned group and everyone else
+// keep their existing relative order (i.e. whatever sort field is active).
 void ReorderPinnedShips(void* list)
 {
   if (!list) return;
@@ -129,10 +130,11 @@ void ReorderPinnedShips(void* list)
     ships.push_back(std::move(entry));
   }
 
-  // rank[i] == pinned_words.size() means "not pinned"; anything less is the
-  // index into cfg.pinned_ships (i.e. pin priority) it was claimed for.
-  const int        unpinned_rank = static_cast<int>(pinned_words.size());
-  std::vector<int> ranks(count, unpinned_rank);
+  // Pinned ships get rank 0, everyone else rank 1; the stable_sort below then
+  // preserves each group's existing (actively-sorted) relative order.
+  constexpr int    kPinnedRank   = 0;
+  constexpr int    kUnpinnedRank = 1;
+  std::vector<int> ranks(count, kUnpinnedRank);
 
   bool any_pinned = false;
   for (size_t p = 0; p < pinned_words.size(); ++p) {
@@ -141,7 +143,7 @@ void ReorderPinnedShips(void* list)
     int     best_index = -1;
     int64_t best_level = -1;
     for (int32_t i = 0; i < count; ++i) {
-      if (ranks[i] != unpinned_rank) continue; // already claimed by an earlier pinned_ships entry
+      if (ranks[i] != kUnpinnedRank) continue; // already claimed by an earlier pinned_ships entry
       if (!ShipNameMatch::MatchesAny(ships[i].match_words, pinned_words[p])) continue;
       if (ships[i].level > best_level) {
         best_level = ships[i].level;
@@ -150,7 +152,7 @@ void ReorderPinnedShips(void* list)
     }
 
     if (best_index >= 0) {
-      ranks[best_index] = static_cast<int>(p);
+      ranks[best_index] = kPinnedRank;
       any_pinned        = true;
     } else {
       spdlog::warn("[PinnedShipSort] pinned_ships entry '{}' matched no idle ship (check the debug log above "

--- a/mods/src/patches/parts/pinned_ship_sort.cc
+++ b/mods/src/patches/parts/pinned_ship_sort.cc
@@ -1,0 +1,228 @@
+#include "config.h"
+#include "errormsg.h"
+#include "ship_name_match.h"
+
+#include <prime/FleetPlayerData.h>
+#include <prime/HullSpec.h>
+
+#include <il2cpp/il2cpp-functions.h>
+#include <il2cpp/il2cpp_helper.h>
+
+#include <spdlog/spdlog.h>
+#include <spud/detour.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+// Fleet management dock ship sort: hooks ShipManagementViewContext.Sort()
+// and stable-partitions cfg.pinned_ships to the front of SortedIdleShips,
+// keeping everyone else in their existing order. Only the concrete class is
+// hooked, not ISortedFleetsContext, so HailingFrequenciesInventoryContext is
+// unaffected. Matching is shared with the instant-warp filters (ship_name_match.h).
+// If multiple ships share a pinned name, only the highest-level unclaimed one is pinned.
+
+namespace {
+
+struct PinnedShipSortState {
+  IL2CppClassHelper* shipManagementViewContext = nullptr;
+  IL2CppFieldHelper* sortedIdleShipsField      = nullptr;
+  bool               valid                     = false;
+};
+
+PinnedShipSortState& State()
+{
+  static PinnedShipSortState s;
+  return s;
+}
+
+bool InitializeState()
+{
+  auto& s = State();
+
+  s.shipManagementViewContext = new IL2CppClassHelper(
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Ships", "ShipManagementViewContext"));
+  if (!s.shipManagementViewContext->get_cls()) {
+    ErrorMsg::MissingHelper("Digit.Prime.Ships", "ShipManagementViewContext");
+    return false;
+  }
+
+  s.sortedIdleShipsField = new IL2CppFieldHelper(s.shipManagementViewContext->GetField("SortedIdleShips"));
+  if (!s.sortedIdleShipsField->isValidHelper()) {
+    spdlog::error("[PinnedShipSort] ShipManagementViewContext field layout changed");
+    return false;
+  }
+
+  s.valid = true;
+  return true;
+}
+
+struct ShipEntry {
+  void*                                 item;
+  std::vector<std::vector<std::string>> match_words; // word-sequences from HullSpec.Name and HullSpec.IdStr
+  int64_t                               level;
+  std::string                           debug_name;  // raw HullSpec.Name, for diagnostics
+  std::string                           debug_idstr; // raw HullSpec.IdStr, for diagnostics
+};
+
+ShipEntry BuildShipEntry(void* item)
+{
+  ShipEntry entry{item, {}, 0, {}, {}};
+
+  auto* ship = reinterpret_cast<FleetPlayerData*>(item);
+  if (!ship) return entry;
+
+  entry.level       = ship->Level;
+  entry.match_words = ShipNameMatch::CandidateWords(ship, &entry.debug_name, &entry.debug_idstr);
+  return entry;
+}
+
+// Stable-partitions `list` (a List<FleetPlayerData>) so that ships matching
+// cfg.pinned_ships come first, ordered by their position in that config list,
+// while every other ship keeps its existing relative order.
+void ReorderPinnedShips(void* list)
+{
+  if (!list) return;
+
+  const auto& cfg = Config::Get();
+  if (cfg.pinned_ships.empty()) return;
+
+  auto* listClass = il2cpp_object_get_class(reinterpret_cast<Il2CppObject*>(list));
+  if (!listClass) return;
+
+  auto* getCount = il2cpp_class_get_method_from_name(listClass, "get_Count", 0);
+  auto* getItem  = il2cpp_class_get_method_from_name(listClass, "get_Item", 1);
+  auto* clear    = il2cpp_class_get_method_from_name(listClass, "Clear", 0);
+  auto* add      = il2cpp_class_get_method_from_name(listClass, "Add", 1);
+  if (!getCount || !getItem || !clear || !add) {
+    spdlog::warn("[PinnedShipSort] SortedIdleShips list is missing expected List<T> methods");
+    return;
+  }
+
+  Il2CppException* exc = nullptr;
+  auto* countObj = il2cpp_runtime_invoke(getCount, list, nullptr, &exc);
+  if (exc || !countObj) return;
+  const auto count = *reinterpret_cast<int32_t*>(il2cpp_object_unbox(countObj));
+  if (count <= 1) return;
+  if (count > 2000) {
+    spdlog::warn("[PinnedShipSort] SortedIdleShips reported an implausible count ({}); skipping", count);
+    return;
+  }
+
+  // cfg.pinned_ships entries are already normalized (see parse_ship_filter /
+  // ShipNameMatch::NormalizeKey in config.cc); just split them into words.
+  std::vector<std::vector<std::string>> pinned_words;
+  pinned_words.reserve(cfg.pinned_ships.size());
+  for (const auto& name : cfg.pinned_ships) pinned_words.push_back(ShipNameMatch::SplitWords(name));
+
+  std::vector<ShipEntry> ships;
+  ships.reserve(count);
+  for (int32_t i = 0; i < count; ++i) {
+    void* idxArgs[1] = {&i};
+    exc              = nullptr;
+    auto* item       = il2cpp_runtime_invoke(getItem, list, idxArgs, &exc);
+    if (exc) item = nullptr;
+
+    auto entry = BuildShipEntry(item);
+    spdlog::debug("[PinnedShipSort] idle ship: name='{}' idstr='{}' level={}", entry.debug_name,
+                 entry.debug_idstr, entry.level);
+    ships.push_back(std::move(entry));
+  }
+
+  // rank[i] == pinned_words.size() means "not pinned"; anything less is the
+  // index into cfg.pinned_ships (i.e. pin priority) it was claimed for.
+  const int        unpinned_rank = static_cast<int>(pinned_words.size());
+  std::vector<int> ranks(count, unpinned_rank);
+
+  bool any_pinned = false;
+  for (size_t p = 0; p < pinned_words.size(); ++p) {
+    if (pinned_words[p].empty()) continue;
+
+    int     best_index = -1;
+    int64_t best_level = -1;
+    for (int32_t i = 0; i < count; ++i) {
+      if (ranks[i] != unpinned_rank) continue; // already claimed by an earlier pinned_ships entry
+      if (!ShipNameMatch::MatchesAny(ships[i].match_words, pinned_words[p])) continue;
+      if (ships[i].level > best_level) {
+        best_level = ships[i].level;
+        best_index = i;
+      }
+    }
+
+    if (best_index >= 0) {
+      ranks[best_index] = static_cast<int>(p);
+      any_pinned        = true;
+    } else {
+      spdlog::warn("[PinnedShipSort] pinned_ships entry '{}' matched no idle ship (check the debug log above "
+                   "for each ship's actual name/idstr)",
+                   cfg.pinned_ships[p]);
+    }
+  }
+
+  if (!any_pinned) return;
+
+  std::vector<void*> items;
+  items.reserve(count);
+  for (const auto& entry : ships) items.push_back(entry.item);
+
+  std::vector<int> order(count);
+  for (int32_t i = 0; i < count; ++i) order[i] = i;
+  std::ranges::stable_sort(order, [&](int a, int b) { return ranks[a] < ranks[b]; });
+
+  bool changed = false;
+  for (int32_t i = 0; i < count; ++i) {
+    if (order[i] != i) {
+      changed = true;
+      break;
+    }
+  }
+  if (!changed) return;
+
+  exc = nullptr;
+  il2cpp_runtime_invoke(clear, list, nullptr, &exc);
+  if (exc) {
+    spdlog::warn("[PinnedShipSort] list.Clear raised an exception; aborting reorder");
+    return;
+  }
+
+  for (int32_t i = 0; i < count; ++i) {
+    void* addArgs[1] = {items[order[i]]};
+    exc               = nullptr;
+    il2cpp_runtime_invoke(add, list, addArgs, &exc);
+    if (exc) {
+      spdlog::warn("[PinnedShipSort] list.Add raised an exception while re-inserting an item");
+    }
+  }
+}
+
+void ShipManagementViewContext_Sort_Hook(auto original, void* _this)
+{
+  original(_this);
+
+  auto& s = State();
+  if (!s.valid) return;
+
+  auto* list = *reinterpret_cast<void**>(reinterpret_cast<char*>(_this) + s.sortedIdleShipsField->offset());
+  ReorderPinnedShips(list);
+}
+
+} // namespace
+
+void InstallPinnedShipSortHooks()
+{
+  if (!InitializeState()) {
+    spdlog::error("[PinnedShipSort] initialization failed; hooks not installed");
+    return;
+  }
+
+  auto& s = State();
+
+  auto sortMethod = s.shipManagementViewContext->GetMethod("Sort", 0);
+  if (!sortMethod) {
+    ErrorMsg::MissingMethod("ShipManagementViewContext", "Sort");
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(sortMethod, ShipManagementViewContext_Sort_Hook);
+  spdlog::info("Pinned ship sort: hooks installed");
+}

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -42,6 +42,7 @@ void InstallLoadingTipHooks();
 void InstallFocusSearchHooks();
 void InstallCargoFormatHooks();
 void InstallOfficerSortHooks();
+void InstallPinnedShipSortHooks();
 void InstallInstantWarpConfirmationHooks();
 void InstallForbiddenTechConfirmationHooks();
 void InstallAudioEventHooks();
@@ -141,6 +142,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"FocusSearch",          {InstallFocusSearchHooks,      &cfg.installFocusSearchHooks}},
       {"CargoFormat",          {InstallCargoFormatHooks,      &cfg.installCargoFormatHooks}},
       {"OfficerSortHooks",     {InstallOfficerSortHooks,      &cfg.installOfficerSortHooks}},
+      {"PinnedShipSort",       {InstallPinnedShipSortHooks,   &cfg.installPinnedShipSortHooks}},
       {"InstantWarpConfirm",   {InstallInstantWarpConfirmationHooks, &cfg.installInstantWarpConfirmationHooks}},
       {"ForbiddenTechConfirm", {InstallForbiddenTechConfirmationHooks, &cfg.auto_confirm_ft_upgrade}},
       {"AudioEvents",          {InstallAudioEventHooks,                 &cfg.installAudioEventHooks}},

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -43,6 +43,7 @@ void InstallFocusSearchHooks();
 void InstallCargoFormatHooks();
 void InstallOfficerSortHooks();
 void InstallPinnedShipSortHooks();
+void InstallDoubleClickAssignShipHooks();
 void InstallInstantWarpConfirmationHooks();
 void InstallForbiddenTechConfirmationHooks();
 void InstallAudioEventHooks();
@@ -143,6 +144,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"CargoFormat",          {InstallCargoFormatHooks,      &cfg.installCargoFormatHooks}},
       {"OfficerSortHooks",     {InstallOfficerSortHooks,      &cfg.installOfficerSortHooks}},
       {"PinnedShipSort",       {InstallPinnedShipSortHooks,   &cfg.installPinnedShipSortHooks}},
+      {"DoubleClickAssignShip", {InstallDoubleClickAssignShipHooks, &cfg.double_click_to_assign_ship}},
       {"InstantWarpConfirm",   {InstallInstantWarpConfirmationHooks, &cfg.installInstantWarpConfirmationHooks}},
       {"ForbiddenTechConfirm", {InstallForbiddenTechConfirmationHooks, &cfg.auto_confirm_ft_upgrade}},
       {"AudioEvents",          {InstallAudioEventHooks,                 &cfg.installAudioEventHooks}},

--- a/mods/src/prime/AssignShipsWidget.h
+++ b/mods/src/prime/AssignShipsWidget.h
@@ -2,12 +2,14 @@
 
 #include <il2cpp/il2cpp_helper.h>
 
+#include "ButtonAndContextWrapper.h"
 #include "InputFieldWidget.h"
 
 struct AssignShipsWidget {
 public:
   __declspec(property(get = __get__inputField)) InputFieldWidget* _inputField;
   __declspec(property(get = __get_isActiveAndEnabled)) bool        isActiveAndEnabled;
+  __declspec(property(get = __get__assignButton)) ButtonAndContextWrapper* _assignButton;
 
 private:
   friend class ObjectFinder<AssignShipsWidget>;
@@ -29,5 +31,11 @@ public:
   {
     static auto field = get_class_helper().GetProperty("isActiveAndEnabled");
     return field.Get<bool>(this);
+  }
+
+  ButtonAndContextWrapper* __get__assignButton()
+  {
+    static auto field = get_class_helper().GetField("_assignButton").offset();
+    return *(ButtonAndContextWrapper**)((uintptr_t)this + field);
   }
 };

--- a/mods/src/prime/AssignShipsWidget.h
+++ b/mods/src/prime/AssignShipsWidget.h
@@ -4,12 +4,14 @@
 
 #include "ButtonAndContextWrapper.h"
 #include "InputFieldWidget.h"
+#include "SelectableList.h"
 
 struct AssignShipsWidget {
 public:
   __declspec(property(get = __get__inputField)) InputFieldWidget* _inputField;
   __declspec(property(get = __get_isActiveAndEnabled)) bool        isActiveAndEnabled;
   __declspec(property(get = __get__assignButton)) ButtonAndContextWrapper* _assignButton;
+  __declspec(property(get = __get__selectableList)) SelectableList* _selectableList;
 
 private:
   friend class ObjectFinder<AssignShipsWidget>;
@@ -37,5 +39,11 @@ public:
   {
     static auto field = get_class_helper().GetField("_assignButton").offset();
     return *(ButtonAndContextWrapper**)((uintptr_t)this + field);
+  }
+
+  SelectableList* __get__selectableList()
+  {
+    static auto field = get_class_helper().GetField("_selectableList").offset();
+    return *(SelectableList**)((uintptr_t)this + field);
   }
 };

--- a/mods/src/prime/ButtonAndContextWrapper.h
+++ b/mods/src/prime/ButtonAndContextWrapper.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+#include "GenericButtonWidget.h"
+
+struct ButtonAndContextWrapper {
+public:
+  __declspec(property(get = __get_Widget)) GenericButtonWidget* Widget;
+
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "ButtonAndContextWrapper");
+    return class_helper;
+  }
+
+  GenericButtonWidget* __get_Widget()
+  {
+    static auto field = get_class_helper().GetField("Widget").offset();
+    return *(GenericButtonWidget**)((char*)this + field);
+  }
+};

--- a/mods/src/prime/FleetPlayerData.h
+++ b/mods/src/prime/FleetPlayerData.h
@@ -37,6 +37,7 @@ public:
   __declspec(property(get = __get_Id)) uint64_t Id;
   __declspec(property(get = __get_Hull)) HullSpec* Hull;
   __declspec(property(get = __get_Address)) void* Address;
+  __declspec(property(get = __get_Level)) int64_t Level;
 
 private:
   static IL2CppClassHelper& get_class_helper()
@@ -60,17 +61,26 @@ public:
   FleetState __get_CurrentState()
   {
     static auto field = get_class_helper().GetProperty("CurrentState");
-    return *field.Get<FleetState>(this);
+    auto*      value  = field.Get<FleetState>(this);
+    return value ? *value : FleetState::Unknown;
   }
   FleetState __get_PreviousState()
   {
     static auto field = get_class_helper().GetProperty("PreviousState");
-    return *field.Get<FleetState>(this);
+    auto*      value  = field.Get<FleetState>(this);
+    return value ? *value : FleetState::Unknown;
   }
   
   uint64_t __get_Id()
   {
     static auto field = get_class_helper().GetProperty("Id");
-    return *field.Get<uint64_t>(this);
+    auto*      value  = field.Get<uint64_t>(this);
+    return value ? *value : 0;
+  }
+  int64_t __get_Level()
+  {
+    static auto field = get_class_helper().GetProperty("Level");
+    auto*      value  = field.Get<int64_t>(this);
+    return value ? *value : 0;
   }
 };

--- a/mods/src/prime/FleetPlayerData.h
+++ b/mods/src/prime/FleetPlayerData.h
@@ -38,6 +38,7 @@ public:
   __declspec(property(get = __get_Hull)) HullSpec* Hull;
   __declspec(property(get = __get_Address)) void* Address;
   __declspec(property(get = __get_Level)) int64_t Level;
+  __declspec(property(get = __get_HasShip)) bool HasShip;
 
 private:
   static IL2CppClassHelper& get_class_helper()
@@ -82,5 +83,12 @@ public:
     static auto field = get_class_helper().GetProperty("Level");
     auto*      value  = field.Get<int64_t>(this);
     return value ? *value : 0;
+  }
+
+  bool __get_HasShip()
+  {
+    static auto field = get_class_helper().GetProperty("HasShip");
+    auto*      value  = field.Get<bool>(this);
+    return value ? *value : false;
   }
 };

--- a/mods/src/prime/HullSpec.h
+++ b/mods/src/prime/HullSpec.h
@@ -16,6 +16,7 @@ struct HullSpec {
 public:
   __declspec(property(get = __get_Id)) long Id;
   __declspec(property(get = __get_Name)) Il2CppString* Name;
+  __declspec(property(get = __get_IdStr)) Il2CppString* IdStr;
   __declspec(property(get = __get_Type)) HullType Type;
 
 private:
@@ -36,6 +37,12 @@ public:
   Il2CppString* __get_Name()
   {
     static auto field = get_class_helper().GetField("name_").offset();
+    return *(Il2CppString**)((char*)this + field);
+  }
+
+  Il2CppString* __get_IdStr()
+  {
+    static auto field = get_class_helper().GetField("idStr_").offset();
     return *(Il2CppString**)((char*)this + field);
   }
 

--- a/mods/src/prime/SelectableList.h
+++ b/mods/src/prime/SelectableList.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <il2cpp/il2cpp-functions.h>
+#include <il2cpp/il2cpp_helper.h>
+
+#include "errormsg.h"
+
+struct SelectableList {
+public:
+  __declspec(property(get = __get_SelectedIndex)) int32_t SelectedIndex;
+  __declspec(property(get = __get_Count)) int32_t Count;
+
+  bool RequestSelect(int32_t index, bool simulated = false)
+  {
+    static auto RequestSelectWarn   = true;
+    static auto RequestSelectMethod =
+        get_selectable_list_base_helper().GetMethodSpecial<void(SelectableList*, int32_t, bool)>(
+            "RequestSelect", [](auto count, auto params) {
+              if (count != 2) {
+                return false;
+              }
+              return params[0]->type == IL2CPP_TYPE_I4;
+            });
+
+    if (RequestSelectMethod) {
+      RequestSelectMethod(this, index, simulated);
+      return true;
+    } else if (RequestSelectWarn) {
+      RequestSelectWarn = false;
+      ErrorMsg::MissingMethod("SelectableListBase", "RequestSelect");
+    }
+
+    return false;
+  }
+
+  void* DataItem(int32_t index)
+  {
+    static auto dataProp = get_selectable_list_base_helper().GetProperty("Data");
+    auto*       list     = dataProp.GetRaw<Il2CppObject>(this);
+    if (!list) return nullptr;
+
+    auto* listClass = il2cpp_object_get_class(list);
+    if (!listClass) return nullptr;
+
+    auto* getItem = il2cpp_class_get_method_from_name(listClass, "get_Item", 1);
+    if (!getItem) return nullptr;
+
+    Il2CppException* exception = nullptr;
+    void*             args[1]  = {&index};
+    auto*             item     = il2cpp_runtime_invoke(getItem, list, args, &exception);
+    if (exception) return nullptr;
+
+    return item;
+  }
+
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "SelectableList");
+    return class_helper;
+  }
+
+private:
+  static IL2CppClassHelper& get_selectable_list_base_helper()
+  {
+    static IL2CppClassHelper class_helper = get_class_helper().GetParent("SelectableListBase");
+    return class_helper;
+  }
+
+  static IL2CppClassHelper& get_base_list_container_helper()
+  {
+    static IL2CppClassHelper class_helper = get_class_helper().GetParent("BaseListContainer");
+    return class_helper;
+  }
+
+public:
+  int32_t __get_SelectedIndex()
+  {
+    static auto field = get_class_helper().GetProperty("SelectedIndex");
+    return *field.Get<int32_t>(this);
+  }
+
+  int32_t __get_Count()
+  {
+    static auto field = get_base_list_container_helper().GetProperty("Count");
+    return *field.Get<int32_t>(this);
+  }
+};

--- a/mods/src/prime/ShipTileWidget.h
+++ b/mods/src/prime/ShipTileWidget.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <il2cpp/il2cpp_helper.h>
+
+#include "FleetPlayerData.h"
+#include "Widget.h"
+
+struct ShipTileWidget : public Widget<FleetPlayerData, ShipTileWidget> {
+public:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Ships", "ShipTileWidget");
+    return class_helper;
+  }
+
+private:
+  friend struct Widget<FleetPlayerData, ShipTileWidget>;
+};

--- a/mods/src/ship_name_match.h
+++ b/mods/src/ship_name_match.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "str_utils.h"
+
+#include <prime/FleetPlayerData.h>
+#include <prime/HullSpec.h>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Shared ship-name matching for pinned_ships and the instant_warp_* filters.
+// Compares a config entry against a ship's HullSpec.Name and HullSpec.IdStr,
+// normalized and matched on trailing words only (so "Athena" matches "USS
+// Academy Athena" without a generic "Titan" matching "Titan-A").
+namespace ShipNameMatch {
+
+// Upper-cases, drops "_LIVE"/abbreviation dots/apostrophes, turns
+// underscores/hyphens into spaces, and makes a leading "USS " optional.
+inline std::string NormalizeKey(std::string_view raw)
+{
+  auto upper = AsciiStrToUpper(raw);
+  upper      = std::string(StripSuffix(upper, "_LIVE"));
+
+  std::string cleaned;
+  cleaned.reserve(upper.size());
+  for (const char c : upper) {
+    if (c == '_' || c == '-') {
+      cleaned.push_back(' ');
+    } else if (c == '.' || c == '\'') {
+      continue; // drop, don't split: "U.S.S." -> "USS", not "U S S"
+    } else {
+      cleaned.push_back(c);
+    }
+  }
+
+  std::string collapsed;
+  collapsed.reserve(cleaned.size());
+  bool prev_space = false;
+  for (const char c : cleaned) {
+    const bool is_space = (c == ' ');
+    if (is_space && prev_space) continue;
+    collapsed.push_back(c);
+    prev_space = is_space;
+  }
+
+  auto trimmed = StripAsciiWhitespace(collapsed);
+  return std::string(StripPrefix(trimmed, "USS "));
+}
+
+inline std::vector<std::string> SplitWords(std::string_view key)
+{
+  std::vector<std::string> words;
+  std::string              current;
+  for (const char c : key) {
+    if (c == ' ') {
+      if (!current.empty()) {
+        words.push_back(std::move(current));
+        current.clear();
+      }
+    } else {
+      current.push_back(c);
+    }
+  }
+  if (!current.empty()) words.push_back(std::move(current));
+  return words;
+}
+
+// True if `pinned` is a trailing (suffix) subsequence of `candidate`'s words,
+// e.g. pinned=["ATHENA"] matches candidate=["ACADEMY","ATHENA"].
+inline bool EndsWithWords(const std::vector<std::string>& candidate, const std::vector<std::string>& pinned)
+{
+  if (pinned.empty() || candidate.size() < pinned.size()) return false;
+  const size_t offset = candidate.size() - pinned.size();
+  for (size_t i = 0; i < pinned.size(); ++i) {
+    if (candidate[offset + i] != pinned[i]) return false;
+  }
+  return true;
+}
+
+// Ships whose HullSpec.Name/IdStr share no words with what players actually
+// call them (e.g. GS-31's HullSpec.Name is "Junker"). `canonical` must exactly
+// match one of a ship's normal candidates for its aliases to apply.
+struct ShipAliasGroup {
+  std::string_view              canonical;
+  std::vector<std::string_view> aliases;
+};
+
+inline const std::vector<ShipAliasGroup>& KnownShipAliases()
+{
+  static const std::vector<ShipAliasGroup> groups = {
+      {"Junker", {"GS-31"}},
+      {"Franklin 2.0", {"Franklin-A"}},
+      {"Vidar 2", {"Vidar Talios", "Talios", "Vi'dar Talios"}},
+      {"USS Luna", {"USS Beatty", "Beatty"}},
+      {"D'Vor NanDi", {"D'Vor Feesha", "Feesha", "Dvor Feesha"}},
+      {"ROM_KID_Aug", {"Hijacked Legionary"}},
+      {"FED_KID_Aug", {"Hijacked USS Mayflower", "Hijacked Mayflower"}},
+      {"KLG_KID_Aug", {"Hijacked D3", "Hijacked D3 Class"}},
+  };
+  return groups;
+}
+
+// Word-sequences from a ship's Name/IdStr plus any known aliases (see
+// KnownShipAliases). Optionally captures the raw strings for diagnostics.
+inline std::vector<std::vector<std::string>> CandidateWords(FleetPlayerData* ship, std::string* debug_name = nullptr,
+                                                             std::string* debug_idstr = nullptr)
+{
+  std::vector<std::vector<std::string>> candidates;
+  if (!ship) return candidates;
+
+  const auto hull = ship->Hull;
+  if (!hull) return candidates;
+
+  if (const auto name = hull->Name; name != nullptr) {
+    const auto raw = to_string(name);
+    if (debug_name) *debug_name = raw;
+    if (auto words = SplitWords(NormalizeKey(raw)); !words.empty()) {
+      candidates.push_back(std::move(words));
+    }
+  }
+
+  if (const auto idstr = hull->IdStr; idstr != nullptr) {
+    const auto raw = to_string(idstr);
+    if (debug_idstr) *debug_idstr = raw;
+    if (auto words = SplitWords(NormalizeKey(raw));
+        !words.empty() && std::ranges::find(candidates, words) == candidates.end()) {
+      candidates.push_back(std::move(words));
+    }
+  }
+
+  for (const auto& group : KnownShipAliases()) {
+    const auto canonical_words = SplitWords(NormalizeKey(group.canonical));
+    if (canonical_words.empty()) continue;
+    const bool is_this_ship =
+        std::ranges::any_of(candidates, [&](const auto& words) { return words == canonical_words; });
+    if (!is_this_ship) continue;
+
+    for (const auto alias : group.aliases) {
+      if (auto words = SplitWords(NormalizeKey(alias));
+          !words.empty() && std::ranges::find(candidates, words) == candidates.end()) {
+        candidates.push_back(std::move(words));
+      }
+    }
+  }
+
+  return candidates;
+}
+
+// True if any of `candidates` ends with `pinned_words`.
+inline bool MatchesAny(const std::vector<std::vector<std::string>>& candidates,
+                       const std::vector<std::string>& pinned_words)
+{
+  return std::ranges::any_of(candidates, [&](const auto& words) { return EndsWithWords(words, pinned_words); });
+}
+
+} // namespace ShipNameMatch

--- a/mods/src/str_utils.h
+++ b/mods/src/str_utils.h
@@ -47,6 +47,14 @@ constexpr std::string_view StripSuffix(std::string_view str, const std::string_v
   return str;
 }
 
+constexpr std::string_view StripPrefix(std::string_view str, const std::string_view prefix)
+{
+  if (str.size() >= prefix.size() && str.substr(0, prefix.size()) == prefix) {
+    return str.substr(prefix.size());
+  }
+  return str;
+}
+
 constexpr std::string AsciiStrToUpper(const std::string_view s)
 {
   std::string str = s.data();


### PR DESCRIPTION
## Fleet management improvements: pin ships, arrow-key navigation, and double-click assign

### Background

The fleet management dock (where you assign ships to a fleet) ships in a fixed sort order with no way to keep your most-used ships grouped at the front. Selecting the next/previous ship requires mouse-clicking each tile, and assigning a ship is a two-step "select then click Assign" action. This PR adds three opt-in quality-of-life features for that screen, plus a shared ship-name matcher that also benefits the existing instant-warp filters.

### What's new

**`pinned_ships`** (default `""`, on by default as a patch) — a comma-separated list of ship names that are always stable-partitioned to the front of the fleet management dock. The active sort field's order is preserved within both the pinned group and the unpinned group, so pinning doesn't fight the selected sort. Matching is trailing-word based, so `"Athena"` matches `"USS Academy Athena"` without a generic `"Titan"` accidentally matching `"Titan-A"`. Only the concrete `ShipManagementViewContext.Sort()` is hooked — `HailingFrequenciesInventoryContext` and other `ISortedFleetsContext` implementations are unaffected.

**`arrow_keys_to_select_ship`** (default `true`) — Left/Right arrow keys step the selected ship tile in the fleet management dock. The trailing "Build Ship" tile shares the same list as real ships; selecting it (even just highlighting) immediately opens the ship builder, so arrow-key navigation now inspects the underlying list data via `SelectableListBase.Data` and skips any entry that is null or whose `FleetPlayerData.HasShip` is false — landing only on real ships.

**`double_click_to_assign_ship`** (default `false`) — double-clicking a ship tile presses the Assign button directly, instead of select-then-click-Assign. Detection is timed against a 400 ms window (Unity's `Button.onClick` doesn't report click count) and keyed off the tile's bound `FleetPlayerData` context so reused/pooled list rows don't misfire across different ships.

### Additional changes

- **Shared `ship_name_match.h`** — the trailing-word ship-name matching logic is extracted into a shared header and reused by both `pinned_ships` and the existing `instant_warp_*` filters. The instant-warp filters now match against both `HullSpec.Name` and `HullSpec.IdStr` candidates instead of only the hull name, making them more robust.
- **New "Fleet Management" subgroup** in all four localized example config files (en, de, fr, nl), placed between Donations and HUD, keeping line counts aligned across localizations.

### How to verify

1. **Pinned ships** — set `pinned_ships = "Athena, Discovery"`, open the fleet management dock, and confirm those ships appear first while the remaining ships keep the active sort order. Change the sort field and confirm the pinned ships re-sort among themselves but stay in front.
2. **Arrow keys** — with `arrow_keys_to_select_ship = true` (default), open the fleet management dock and press Left/Right. Selection should step between real ships only; arrowing toward the "Build Ship" tile should stop at the last real ship rather than opening the builder.
3. **Double-click assign** — set `double_click_to_assign_ship = true`, double-click a ship tile in the dock, and confirm it assigns immediately. Single-click should still only select.
4. **Instant-warp filters** — confirm existing `instant_warp_auto_jump` / `instant_warp_auto_warp` / `instant_warp_always_ask` filters still match (now also via `IdStr`, so edge cases like live/abbreviation variants should resolve).

### Risks

- **`pinned_ships` matching is fuzzy** — trailing-word matching means a short configured name could match more than one ship (e.g. `"Titan"` matches both `"Titan"` and `"USS Titan"`). If multiple ships share a pinned name, only the highest-level unclaimed one is pinned. If Scopely adds new ships, this will need to be maintained because there is a non-zero chance that the internal name won't match the in game name (looking at you, GS-31 "Junker").
- **`arrow_keys_to_select_ship` reads list data via IL2CPP reflection** — `SelectableListBase.Data` is indexed via runtime `get_Item` invocation each step. This is a read-only operation with no side effects, but depends on the list's concrete type exposing `get_Item(int)`. If the game changes the backing list type, navigation would silently stop at edges (logs `no further real ship in that direction`) rather than crash.
- **`double_click_to_assign_ship` is off by default** — the existing single-click-then-Assign flow is unchanged unless explicitly enabled.

### Points to argue about

- **The "Build ship" tile** — I decided to keep it as a separator between the pinned ships and the other ships because I like the visual separation. This has the side effect that the arrow key navigation between ships has to jump that tile. Happy to adjust this part if anyone has a better idea.
- **What's the first ship?"** — When we first go into the screen, no ship tile is selected. Current behaviour is that once the user starts to arrow right, we start at the very left with the first ship. Another option would be to always start at the currently assigned ship. I have no strong preference here, but I figured if people pin ships they will be first in the list so starting at the front will make it more likely that they get the ship they want fastest.
- **Sort logic for pinned ships** — The way I implemented pinned ships now, they just get the same sort order applied as all the other ships, depending on the selected sort option. Initially I just kept the pinned ships in the same order as in the config file no matter what, but then the sort order selector has no effect on them at all and that also seemed a bit weird. I figured this way is most intuitive for the first iteration, adding a `preserve_pin_order` setting later on would be easy if people ask for it.