### PR TITLE
Feature/per faction bulk daily claims

### DIFF
--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -231,6 +231,7 @@ focussearch = true
 freeresizehooks = true
 game_version = true
 giftsbulkclaimhooks = true
+dailyfactionbulkclaimhooks = true
 hotkeyhooks = true
 loadingscreenhooks = true
 miscpatches = true
@@ -619,6 +620,14 @@ instant_warp_auto_jump = ""
 
 # Comma-separated ship hull names to always regular warp; use "*" for all ships or leave blank for none
 instant_warp_auto_warp = ""
+
+# Kommagetrennte Fraktionen (federation, klingon, romulan), für die der Sammel-Einfordern-Schalter der täglichen
+# Ziele gilt; leer lassen, um das Standardverhalten des Spiels beizubehalten
+daily_bulk_claim_factions = ""
+
+# Das Spiel setzt den Schalter "Alle einfordern" der täglichen Ziele bei jedem Neustart auf aus zurück; auf true
+# setzen, um ihn beim ersten Anzeigen des Bildschirms pro Sitzung stattdessen wieder einzuschalten
+daily_bulk_claim_toggle_default_on = false
 
 # Subgroup: Banner
 # ----------------

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -231,6 +231,7 @@ focussearch = true
 freeresizehooks = true
 game_version = true
 giftsbulkclaimhooks = true
+dailyfactionbulkclaimhooks = true
 hotkeyhooks = true
 loadingscreenhooks = true
 miscpatches = true
@@ -619,6 +620,14 @@ instant_warp_auto_jump = ""
 
 # Comma-separated ship hull names to always regular warp; use "*" for all ships or leave blank for none
 instant_warp_auto_warp = ""
+
+# Comma-separated factions (federation, klingon, romulan) for which the Daily Goals bulk-claim toggle applies;
+# leave blank to leave the game's default behaviour untouched
+daily_bulk_claim_factions = ""
+
+# The game resets the Daily Goals "Claim All" toggle to off on every restart; set to true to force it back on
+# the first time the screen is shown each session instead
+daily_bulk_claim_toggle_default_on = false
 
 # Subgroup: Banners
 # -----------------

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -231,6 +231,7 @@ focussearch = true
 freeresizehooks = true
 game_version = true
 giftsbulkclaimhooks = true
+dailyfactionbulkclaimhooks = true
 hotkeyhooks = true
 loadingscreenhooks = true
 miscpatches = true
@@ -619,6 +620,14 @@ instant_warp_auto_jump = ""
 
 # Comma-separated ship hull names to always regular warp; use "*" for all ships or leave blank for none
 instant_warp_auto_warp = ""
+
+# Factions séparées par des virgules (federation, klingon, romulan) auxquelles s'applique le bouton de réclamation
+# groupée des objectifs quotidiens ; laisser vide pour conserver le comportement par défaut du jeu
+daily_bulk_claim_factions = ""
+
+# Le jeu réinitialise le bouton « Tout réclamer » des objectifs quotidiens sur désactivé à chaque redémarrage ;
+# définir sur true pour le réactiver automatiquement la première fois que l'écran est affiché à chaque session
+daily_bulk_claim_toggle_default_on = false
 
 # Subgroup: Banners
 # -----------------

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -231,6 +231,7 @@ focussearch = true
 freeresizehooks = true
 game_version = true
 giftsbulkclaimhooks = true
+dailyfactionbulkclaimhooks = true
 hotkeyhooks = true
 loadingscreenhooks = true
 miscpatches = true
@@ -619,6 +620,14 @@ instant_warp_auto_jump = ""
 
 # Comma-separated ship hull names to always regular warp; use "*" for all ships or leave blank for none
 instant_warp_auto_warp = ""
+
+# Kommagescheiden facties (federation, klingon, romulan) waarvoor de verzamel-claim-schakelaar van de dagelijkse
+# doelen geldt; laat leeg om het standaardgedrag van het spel ongewijzigd te laten
+daily_bulk_claim_factions = ""
+
+# Het spel zet de "Alles claimen"-schakelaar van de dagelijkse doelen bij elke herstart terug op uit; zet op true
+# om deze de eerste keer dat het scherm per sessie wordt getoond in plaats daarvan weer aan te zetten
+daily_bulk_claim_toggle_default_on = false
 
 # Subgroup: Banners
 # -----------------

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -12,6 +12,7 @@
 
 #include "defaultconfig.h"
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <initializer_list>
 #include <iostream>
@@ -454,6 +455,45 @@ void read_instant_warp_filter(toml::table& config, toml::table& new_config, std:
   }
 }
 
+void parse_faction_filter(std::string_view value, std::vector<std::string>& factions)
+{
+  static constexpr std::array kKnownFactions{"federation", "klingon", "romulan"};
+
+  factions.clear();
+  for (const auto& token : StrSplit(std::string(value), ',')) {
+    const auto stripped = StripAsciiWhitespace(token);
+    if (stripped.empty()) continue;
+
+    auto lowered = AsciiStrToLower(stripped);
+
+    if (std::ranges::find(kKnownFactions, lowered) == kKnownFactions.end()) {
+      spdlog::warn("Unrecognised faction '{}' in daily_bulk_claim_factions; expected one of: federation, klingon, "
+                   "romulan. Ignoring.",
+                   stripped);
+      continue;
+    }
+
+    if (std::ranges::find(factions, lowered) == factions.end()) {
+      factions.emplace_back(std::move(lowered));
+    }
+  }
+}
+
+void read_daily_bulk_claim_factions(toml::table& config, toml::table& new_config, std::vector<std::string>& factions,
+                                    std::string_view default_value, bool write_log)
+{
+  const auto value =
+      config["ui"]["daily_bulk_claim_factions"].value<std::string>().value_or(std::string(default_value));
+  parse_faction_filter(value, factions);
+
+  new_config.emplace<toml::table>("ui", toml::table());
+  new_config["ui"].as_table()->insert_or_assign("daily_bulk_claim_factions", std::string(value));
+
+  if (write_log) {
+    spdlog::debug("config value ui.daily_bulk_claim_factions: {}", value);
+  }
+}
+
 void read_sync_targets(toml::table& config, toml::table& new_config,
                        std::map<std::string, SyncTargetConfig>& sync_targets, const SyncConfig& defaults)
 {
@@ -808,6 +848,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "patches", "transitionscreenhooks", DCP::transitionscreenhooks, write_config);
   this->installGiftsBulkClaimHooks =
       get_config_or_default(config, parsed, "patches", "giftsbulkclaimhooks", DCP::giftsbulkclaimhooks, write_config);
+  this->installDailyFactionBulkClaimHooks = get_config_or_default(
+      config, parsed, "patches", "dailyfactionbulkclaimhooks", DCP::dailyfactionbulkclaimhooks, write_config);
   this->installFocusSearchHooks =
       get_config_or_default(config, parsed, "patches", "focussearch", DCP::focussearch, write_config);
   this->installCargoFormatHooks =
@@ -910,7 +952,13 @@ void Config::Load()
   }
   this->installAudioEventHooks = this->trace_audio_events || !this->disabled_audio_events.empty();
   this->auto_open_bulk_claim_flyout = get_config_or_default(config, parsed, "ui", "auto_open_bulk_claim_flyout",
-                                                            DCU::auto_open_bulk_claim_flyout, write_config);
+                                                             DCU::auto_open_bulk_claim_flyout, write_config);
+
+  read_daily_bulk_claim_factions(config, parsed, this->daily_bulk_claim_factions, DCU::daily_bulk_claim_factions,
+                                 write_config);
+  this->daily_bulk_claim_toggle_default_on =
+      get_config_or_default(config, parsed, "ui", "daily_bulk_claim_toggle_default_on",
+                            DCU::daily_bulk_claim_toggle_default_on, write_config);
   this->auto_confirm_instant_warp =
       get_auto_confirm_instant_warp(config, parsed, DCU::auto_confirm_instant_warp, write_config);
   this->installInstantWarpConfirmationHooks = true;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -199,6 +199,10 @@ public:
   bool auto_open_bulk_claim_flyout;
   bool auto_confirm_ft_upgrade;
 
+  std::vector<std::string> daily_bulk_claim_factions;
+
+  bool daily_bulk_claim_toggle_default_on;
+
   InstantWarpConfirmation auto_confirm_instant_warp;
 
   std::vector<std::string> instant_warp_auto_jump;
@@ -246,6 +250,7 @@ public:
   bool installGameVersionHook;
   bool installObjectTracker;
   bool installGiftsBulkClaimHooks;
+  bool installDailyFactionBulkClaimHooks;
   bool installInstantWarpConfirmationHooks;
   bool installAudioEventHooks;
 

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -82,6 +82,7 @@ namespace Patches
   constexpr bool zoomhooks                  = true;
   constexpr bool miscpatches                = true;
   constexpr bool giftsbulkclaimhooks        = true;
+  constexpr bool dailyfactionbulkclaimhooks = true;
   constexpr bool focussearch                = true;
   constexpr bool cargoformathooks           = true;  // on by default: cargo number precision override
   constexpr bool officersorthooks           = true;  // restore Below Deck Ability sort option
@@ -218,6 +219,8 @@ namespace UI
   constexpr bool        auto_confirm_discovery      = true;
   constexpr bool        auto_confirm_ft_upgrade     = false;
   constexpr bool        auto_open_bulk_claim_flyout = false;
+  constexpr const char* daily_bulk_claim_factions   = "";
+  constexpr bool        daily_bulk_claim_toggle_default_on = false;
   constexpr bool        disable_escape_exit         = true;
   constexpr bool        disable_first_popup         = false;
   constexpr bool        disable_galaxy_chat         = false;

--- a/mods/src/patches/parts/daily_faction_bulk_claim.cc
+++ b/mods/src/patches/parts/daily_faction_bulk_claim.cc
@@ -413,20 +413,6 @@ void MissionViewController_AboutToShow(auto original, Il2CppObject* _this)
 
 void MissionViewController_AboutToHide(auto original, Il2CppObject* _this)
 {
-  auto* controller = (MissionViewController*)_this;
-  auto* toggle_tf  = GetTransformOf(controller->ClaimAllToggle());
-  auto* parent     = toggle_tf != nullptr ? toggle_tf->parent : nullptr;
-
-  if (parent != nullptr) {
-    for (const auto& entry : kFactionIconNames) {
-      if (auto* icon_transform = FindChildByName(parent, entry.game_object_name)) {
-        if (auto* go = icon_transform->gameObject) {
-          go->SetActive(true);
-        }
-      }
-    }
-  }
-
   if (g_active_mission_view_controller == _this) {
     g_active_mission_view_controller = nullptr;
   }

--- a/mods/src/patches/parts/daily_faction_bulk_claim.cc
+++ b/mods/src/patches/parts/daily_faction_bulk_claim.cc
@@ -1,0 +1,502 @@
+#include "config.h"
+#include "errormsg.h"
+#include "str_utils.h"
+
+#include <prime/GameObject.h>
+#include <prime/IList.h>
+#include <prime/Transform.h>
+
+#include <il2cpp/il2cpp_helper.h>
+#include <spud/detour.h>
+
+#include <spdlog/fmt/ranges.h>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <string>
+
+namespace
+{
+constexpr std::string_view kFactionPointResourcePrefix = "Resource_FactionPoint_";
+
+class ResourceSpec
+{
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "ResourceSpec");
+    return class_helper;
+  }
+
+public:
+  static IL2CppClassHelper& ClassHelper()
+  {
+    return get_class_helper();
+  }
+};
+
+class InventoryItem
+{
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "InventoryItem");
+    return class_helper;
+  }
+
+public:
+  static IL2CppClassHelper& ClassHelper()
+  {
+    return get_class_helper();
+  }
+};
+
+class MissionViewController
+{
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Missions", "MissionViewController");
+    return class_helper;
+  }
+
+public:
+  static IL2CppClassHelper& ClassHelper()
+  {
+    return get_class_helper();
+  }
+
+  Il2CppObject* ClaimAllToggle()
+  {
+    static auto field = get_class_helper().GetField("_claimAllToggle");
+    return field.isValidHelper() ? *(Il2CppObject**)((ptrdiff_t)this + field.offset()) : nullptr;
+  }
+};
+
+Transform* GetTransformOf(Il2CppObject* component)
+{
+  if (component == nullptr || component->klass == nullptr) {
+    return nullptr;
+  }
+  auto helper = IL2CppClassHelper{component->klass}.GetParent("Component");
+  if (!helper.isValidHelper()) {
+    return nullptr;
+  }
+  return helper.GetProperty("transform").GetRaw<Transform>(component);
+}
+
+Transform* FindChildByName(Transform* root, const char* name)
+{
+  if (root == nullptr) {
+    return nullptr;
+  }
+
+  auto* go = root->gameObject;
+  if (go != nullptr && go->Name() == name) {
+    return root;
+  }
+
+  for (int32_t i = 0; i < root->childCount; ++i) {
+    if (auto* found = FindChildByName(root->GetChild(i), name)) {
+      return found;
+    }
+  }
+
+  return nullptr;
+}
+
+struct FactionIconName {
+  const char* faction;
+  const char* game_object_name;
+};
+
+constexpr FactionIconName kFactionIconNames[] = {
+    {"federation", "Fed_Icon"},
+    {"romulan", "Rom_Icon"},
+    {"klingon", "Klg_Icon"},
+};
+
+void ApplyFactionIconVisibility(Transform* toggle_tf)
+{
+  if (toggle_tf == nullptr) {
+    return;
+  }
+
+  auto* parent = toggle_tf->parent;
+  if (parent == nullptr) {
+    spdlog::debug("[DailyFactionBulkClaim] ApplyFactionIconVisibility: toggle has no parent Transform");
+    return;
+  }
+
+  const auto& configured = Config::Get().daily_bulk_claim_factions;
+
+  for (const auto& entry : kFactionIconNames) {
+    auto* icon_transform = FindChildByName(parent, entry.game_object_name);
+    if (icon_transform == nullptr) {
+      spdlog::debug("[DailyFactionBulkClaim] ApplyFactionIconVisibility: '{}' not found", entry.game_object_name);
+      continue;
+    }
+
+    auto* go = icon_transform->gameObject;
+    if (go == nullptr) {
+      continue;
+    }
+
+    const bool should_show =
+        configured.empty() || std::ranges::find(configured, std::string(entry.faction)) != configured.end();
+    go->SetActive(should_show);
+  }
+}
+
+class UnityEventSystem
+{
+public:
+  static Il2CppObject* Current()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("UnityEngine.UI", "UnityEngine.EventSystems", "EventSystem");
+    static auto get_current = class_helper.GetMethodInfo("get_current", 0);
+    if (get_current == nullptr) {
+      return nullptr;
+    }
+    Il2CppException* exception = nullptr;
+    auto*            result    = il2cpp_runtime_invoke(get_current, nullptr, nullptr, &exception);
+    return exception != nullptr ? nullptr : result;
+  }
+};
+
+class UnityToggle
+{
+private:
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper = il2cpp_get_class_helper("UnityEngine.UI", "UnityEngine.UI", "Toggle");
+    return class_helper;
+  }
+
+public:
+  static IL2CppClassHelper& ClassHelper()
+  {
+    return get_class_helper();
+  }
+
+  static bool IsOn(Il2CppObject* toggle)
+  {
+    if (toggle == nullptr) {
+      return false;
+    }
+    static auto get_is_on = get_class_helper().GetMethodInfo("get_isOn", 0);
+    if (get_is_on == nullptr) {
+      return false;
+    }
+    Il2CppException* exception = nullptr;
+    auto*            result    = il2cpp_runtime_invoke(get_is_on, toggle, nullptr, &exception);
+    if (exception != nullptr || result == nullptr) {
+      return false;
+    }
+    return *(bool*)il2cpp_object_unbox(result);
+  }
+
+  static void SimulateClick(Il2CppObject* toggle)
+  {
+    if (toggle == nullptr) {
+      return;
+    }
+
+    static auto on_pointer_click = get_class_helper().GetMethodInfoSpecial("OnPointerClick", [](auto count, auto) {
+      return count == 1;
+    });
+    if (on_pointer_click == nullptr) {
+      spdlog::debug("[DailyFactionBulkClaim] UnityToggle::SimulateClick: OnPointerClick(PointerEventData) not "
+                   "found");
+      return;
+    }
+
+    static auto event_data_helper =
+        il2cpp_get_class_helper("UnityEngine.UI", "UnityEngine.EventSystems", "PointerEventData");
+    if (event_data_helper.get_cls() == nullptr) {
+      spdlog::debug("[DailyFactionBulkClaim] UnityToggle::SimulateClick: PointerEventData class not found");
+      return;
+    }
+    static auto ctor = event_data_helper.GetMethodInfoSpecial(".ctor", [](auto count, auto) { return count == 1; });
+    if (ctor == nullptr) {
+      spdlog::debug("[DailyFactionBulkClaim] UnityToggle::SimulateClick: PointerEventData(EventSystem) ctor not "
+                   "found");
+      return;
+    }
+
+    auto* event_data = il2cpp_object_new(event_data_helper.get_cls());
+    if (event_data == nullptr) {
+      spdlog::debug("[DailyFactionBulkClaim] UnityToggle::SimulateClick: PointerEventData allocation failed");
+      return;
+    }
+
+    Il2CppException* exception    = nullptr;
+    auto*            event_system = UnityEventSystem::Current();
+    void*            ctor_args[1] = {event_system};
+    il2cpp_runtime_invoke(ctor, event_data, ctor_args, &exception);
+    if (exception != nullptr) {
+      char buffer[256] = {};
+      il2cpp_format_exception(exception, buffer, sizeof(buffer));
+      spdlog::debug("[DailyFactionBulkClaim] UnityToggle::SimulateClick: PointerEventData ctor threw: {}", buffer);
+      return;
+    }
+
+    exception       = nullptr;
+    void* args[1]   = {event_data};
+    il2cpp_runtime_invoke(on_pointer_click, toggle, args, &exception);
+    if (exception != nullptr) {
+      char buffer[256] = {};
+      il2cpp_format_exception(exception, buffer, sizeof(buffer));
+      spdlog::debug("[DailyFactionBulkClaim] UnityToggle::SimulateClick: OnPointerClick invoke threw: {}", buffer);
+    }
+  }
+};
+
+bool          g_applied_default_toggle_on      = false;
+int           g_default_toggle_attempts        = 0;
+Il2CppObject* g_active_mission_view_controller = nullptr;
+
+constexpr int kMaxDefaultToggleAttempts = 300;
+
+void ApplyDefaultToggleOnOnce(MissionViewController* controller)
+{
+  auto* toggle = controller != nullptr ? controller->ClaimAllToggle() : nullptr;
+  if (g_applied_default_toggle_on || !Config::Get().daily_bulk_claim_toggle_default_on || toggle == nullptr) {
+    return;
+  }
+
+  if (UnityToggle::IsOn(toggle)) {
+    g_applied_default_toggle_on = true;
+    return;
+  }
+
+  if (++g_default_toggle_attempts > kMaxDefaultToggleAttempts) {
+    spdlog::warn("[DailyFactionBulkClaim] daily_bulk_claim_toggle_default_on: giving up, toggle never became "
+                "interactable");
+    g_applied_default_toggle_on = true;
+    return;
+  }
+
+  UnityToggle::SimulateClick(toggle);
+
+  if (UnityToggle::IsOn(toggle)) {
+    spdlog::debug("[DailyFactionBulkClaim] daily_bulk_claim_toggle_default_on: forced Claim All toggle on "
+                 "(attempt {})",
+                 g_default_toggle_attempts);
+    g_applied_default_toggle_on = true;
+  }
+}
+
+bool FactionMatches(const std::string& faction_name, const std::vector<std::string>& configured)
+{
+  if (faction_name.empty() || configured.empty()) {
+    return false;
+  }
+  return std::ranges::find(configured, AsciiStrToLower(faction_name)) != configured.end();
+}
+
+std::string FactionNameOfTournament(Il2CppObject* tournament)
+{
+  if (tournament == nullptr || tournament->klass == nullptr) {
+    return {};
+  }
+
+  auto list_field = IL2CppClassHelper{tournament->klass}.GetField("_factionPointRewards");
+  if (!list_field.isValidHelper()) {
+    return {};
+  }
+
+  auto* list_obj = *(Il2CppObject**)((char*)tournament + list_field.offset());
+  if (list_obj == nullptr) {
+    return {};
+  }
+
+  auto* list = (IList*)list_obj;
+  for (int32_t i = 0; i < list->Count; ++i) {
+    auto* item = list->Get(i);
+    if (item == nullptr || item->klass == nullptr) {
+      continue;
+    }
+
+    auto spec_field = IL2CppClassHelper{item->klass}.GetField("_resourceSpec");
+    if (!spec_field.isValidHelper()) {
+      continue;
+    }
+
+    auto* spec = *(Il2CppObject**)((char*)item + spec_field.offset());
+    if (spec == nullptr || spec->klass == nullptr) {
+      continue;
+    }
+
+    auto id_field = IL2CppClassHelper{spec->klass}.GetField("resourceId_");
+    if (!id_field.isValidHelper()) {
+      continue;
+    }
+
+    auto* id_str = *(Il2CppString**)((char*)spec + id_field.offset());
+    if (id_str == nullptr) {
+      continue;
+    }
+
+    auto resource_id = to_string(id_str);
+    if (resource_id.starts_with(kFactionPointResourcePrefix)) {
+      return resource_id.substr(kFactionPointResourcePrefix.size());
+    }
+  }
+
+  return {};
+}
+
+void FilterClaimableDailiesByFaction(IList* list, const std::vector<std::string>& configured)
+{
+  if (list == nullptr) {
+    spdlog::debug("[DailyFactionBulkClaim] GetClaimableDailiesList returned null; nothing to filter");
+    return;
+  }
+
+  const auto total = list->Count;
+  spdlog::debug("[DailyFactionBulkClaim] filtering {} claimable daily(ies) against configured factions [{}]", total,
+               fmt::join(configured, ", "));
+
+  int kept = 0;
+  for (int32_t i = total - 1; i >= 0; --i) {
+    auto* tournament   = list->Get(i);
+    auto  faction_name = FactionNameOfTournament(tournament);
+    auto  matches      = FactionMatches(faction_name, configured);
+
+    spdlog::debug("[DailyFactionBulkClaim]   [{}] faction: '{}' -> {}", i,
+                 faction_name.empty() ? "<none>" : faction_name,
+                 faction_name.empty() ? "keep (not a faction daily)" : (matches ? "keep (claim)" : "remove (skip)"));
+
+    if (!faction_name.empty() && !matches) {
+      list->RemoveAt(i);
+    } else {
+      ++kept;
+    }
+  }
+
+  spdlog::debug("[DailyFactionBulkClaim] kept {}/{} daily(ies) for claiming", kept, total);
+}
+
+IList* MissionViewController_GetClaimableDailiesList(auto original, Il2CppObject* _this)
+{
+  auto* list = (IList*)original(_this);
+
+  auto* controller = (MissionViewController*)_this;
+  ApplyFactionIconVisibility(GetTransformOf(controller->ClaimAllToggle()));
+
+  const auto& configured = Config::Get().daily_bulk_claim_factions;
+  if (configured.empty()) {
+    return list;
+  }
+
+  FilterClaimableDailiesByFaction(list, configured);
+  return list;
+}
+
+void MissionViewController_AboutToShow(auto original, Il2CppObject* _this)
+{
+  original(_this);
+
+  auto* controller = (MissionViewController*)_this;
+  auto* toggle     = controller->ClaimAllToggle();
+  auto* toggle_tf  = GetTransformOf(toggle);
+
+  ApplyFactionIconVisibility(toggle_tf);
+
+  g_active_mission_view_controller = _this;
+}
+
+void MissionViewController_AboutToHide(auto original, Il2CppObject* _this)
+{
+  auto* controller = (MissionViewController*)_this;
+  auto* toggle_tf  = GetTransformOf(controller->ClaimAllToggle());
+  auto* parent     = toggle_tf != nullptr ? toggle_tf->parent : nullptr;
+
+  if (parent != nullptr) {
+    for (const auto& entry : kFactionIconNames) {
+      if (auto* icon_transform = FindChildByName(parent, entry.game_object_name)) {
+        if (auto* go = icon_transform->gameObject) {
+          go->SetActive(true);
+        }
+      }
+    }
+  }
+
+  if (g_active_mission_view_controller == _this) {
+    g_active_mission_view_controller = nullptr;
+  }
+
+  original(_this);
+}
+} // namespace
+
+void DailyFactionBulkClaimUpdate()
+{
+  if (g_active_mission_view_controller != nullptr) {
+    ApplyDefaultToggleOnOnce((MissionViewController*)g_active_mission_view_controller);
+  }
+}
+
+void InstallDailyFactionBulkClaimHooks()
+{
+  auto resource_spec = ResourceSpec::ClassHelper();
+  if (!resource_spec.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.PrimeServer.Models", "ResourceSpec");
+  } else if (!resource_spec.GetField("resourceId_").isValidHelper()) {
+    ErrorMsg::MissingMethod("ResourceSpec", "resourceId_");
+  }
+
+  auto inventory_item = InventoryItem::ClassHelper();
+  if (!inventory_item.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.PrimeServer.Models", "InventoryItem");
+  } else if (!inventory_item.GetField("_resourceSpec").isValidHelper()) {
+    ErrorMsg::MissingMethod("InventoryItem", "_resourceSpec");
+  }
+
+  auto unity_toggle = UnityToggle::ClassHelper();
+  if (!unity_toggle.isValidHelper()) {
+    ErrorMsg::MissingHelper("UnityEngine.UI", "Toggle");
+  } else {
+    if (unity_toggle.GetMethodInfo("get_isOn", 0) == nullptr) {
+      ErrorMsg::MissingMethod("Toggle", "get_isOn");
+    }
+    if (unity_toggle.GetMethodInfoSpecial("OnPointerClick", [](auto count, auto) { return count == 1; })
+        == nullptr) {
+      ErrorMsg::MissingMethod("Toggle", "OnPointerClick");
+    }
+  }
+
+  if (il2cpp_get_class_helper("UnityEngine.UI", "UnityEngine.EventSystems", "PointerEventData").get_cls()
+      == nullptr) {
+    ErrorMsg::MissingHelper("UnityEngine.EventSystems", "PointerEventData");
+  }
+
+  auto mission_view_controller = MissionViewController::ClassHelper();
+  if (!mission_view_controller.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.Prime.Missions", "MissionViewController");
+    return;
+  }
+
+  if (auto ptr = mission_view_controller.GetMethod("GetClaimableDailiesList", 0); ptr == nullptr) {
+    ErrorMsg::MissingMethod("MissionViewController", "GetClaimableDailiesList");
+  } else {
+    SPUD_STATIC_DETOUR(ptr, MissionViewController_GetClaimableDailiesList);
+  }
+
+  if (auto ptr = mission_view_controller.GetMethod("AboutToShow", 0); ptr == nullptr) {
+    ErrorMsg::MissingMethod("MissionViewController", "AboutToShow");
+  } else {
+    SPUD_STATIC_DETOUR(ptr, MissionViewController_AboutToShow);
+  }
+
+  if (auto ptr = mission_view_controller.GetMethod("AboutToHide", 0); ptr == nullptr) {
+    ErrorMsg::MissingMethod("MissionViewController", "AboutToHide");
+  } else {
+    SPUD_STATIC_DETOUR(ptr, MissionViewController_AboutToHide);
+  }
+}

--- a/mods/src/patches/parts/daily_faction_bulk_claim.h
+++ b/mods/src/patches/parts/daily_faction_bulk_claim.h
@@ -1,0 +1,5 @@
+#pragma once
+
+void DailyFactionBulkClaimUpdate();
+
+void InstallDailyFactionBulkClaimHooks();

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -37,6 +37,7 @@
 
 #include "patches/key.h"
 #include "patches/mapkey.h"
+#include "patches/parts/daily_faction_bulk_claim.h"
 #include "patches/parts/focus_search.h"
 
 #include <EASTL/vector.h>
@@ -541,6 +542,8 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
         }
       }
     }
+
+    DailyFactionBulkClaimUpdate();
 
     if (MapKey::IsDown(GameFunction::ActionView)) {
       auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -28,6 +28,7 @@ void InstallToastBannerHooks();
 void InstallPanHooks();
 void InstallHotkeyHooks();
 void InstallGiftsBulkClaimHooks();
+void InstallDailyFactionBulkClaimHooks();
 
 void InstallTestPatches();
 void InstallMiscPatches();
@@ -127,6 +128,8 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"PanHooks", {InstallPanHooks, &cfg.installPanHooks}},
       {"HotkeyHooks", {InstallHotkeyHooks, &cfg.installHotkeyHooks}},
       {"GiftsBulkClaimHooks", {InstallGiftsBulkClaimHooks, &cfg.installGiftsBulkClaimHooks}},
+      {"DailyFactionBulkClaimHooks",
+       {InstallDailyFactionBulkClaimHooks, &cfg.installDailyFactionBulkClaimHooks}},
 #if _WIN32
       {"FreeResizeHooks", {InstallFreeResizeHooks, &cfg.installFreeResizeHooks}},
 #endif

--- a/mods/src/prime/GameObject.h
+++ b/mods/src/prime/GameObject.h
@@ -1,9 +1,30 @@
 #pragma once
 
+#include "str_utils.h"
+
+#include <il2cpp/il2cpp_helper.h>
+
+#include <string>
+
 struct GameObject {
 public:
   __declspec(property(get = __get_activeInHierarchy)) bool activeInHierarchy;
   __declspec(property(get = __get_scene)) void* scene;
+
+  std::string Name()
+  {
+    static auto field = get_class_helper().GetParent("Object").GetProperty("name");
+    auto        str   = field.GetRaw<Il2CppString>(this);
+    return str != nullptr ? to_string(str) : std::string{};
+  }
+
+  void SetActive(bool active)
+  {
+    static auto method = get_class_helper().GetMethod<void(GameObject*, bool)>("SetActive");
+    if (method != nullptr) {
+      method(this, active);
+    }
+  }
 
   template <typename T> T* GetComponentFastPath2()
   {

--- a/mods/src/prime/IList.h
+++ b/mods/src/prime/IList.h
@@ -14,6 +14,15 @@ public:
     return GetImpl(this, index);
   }
 
+  void RemoveAt(int32_t index)
+  {
+    static auto RemoveAtImpl =
+        get_class_helper().GetMethodSpecial2<void(IList*, int32_t)>((Il2CppObject*)(this), "RemoveAt");
+    if (RemoveAtImpl != nullptr) {
+      RemoveAtImpl(this, index);
+    }
+  }
+
 private:
   IL2CppClassHelper& get_class_helper()
   {

--- a/mods/src/prime/Transform.h
+++ b/mods/src/prime/Transform.h
@@ -2,10 +2,14 @@
 
 #include <il2cpp/il2cpp_helper.h>
 
+#include "GameObject.h"
 #include "Vector3.h"
 
 struct Transform {
   __declspec(property(get = __get_LocalScale, put = __set_LocalScale)) Vector3* localScale;
+  __declspec(property(get = __get_ChildCount)) int32_t childCount;
+  __declspec(property(get = __get_GameObject)) GameObject* gameObject;
+  __declspec(property(get = __get_Parent)) Transform* parent;
 
   Vector3* __get_LocalScale()
   {
@@ -19,6 +23,29 @@ struct Transform {
     return prop.SetRaw((void*)this, *v);
   }
 
+  int32_t __get_ChildCount()
+  {
+    static auto field = get_class_helper().GetProperty("childCount");
+    return *field.Get<int32_t>(this);
+  }
+
+  GameObject* __get_GameObject()
+  {
+    static auto field = get_class_helper().GetParent("Component").GetProperty("gameObject");
+    return field.GetRaw<GameObject>(this);
+  }
+
+  Transform* GetChild(int32_t index)
+  {
+    static auto method = get_class_helper().GetMethod<Transform*(Transform*, int32_t)>("GetChild");
+    return method != nullptr ? method(this, index) : nullptr;
+  }
+
+  Transform* __get_Parent()
+  {
+    static auto field = get_class_helper().GetProperty("parent");
+    return field.GetRaw<Transform>(this);
+  }
 
 private:
   static IL2CppClassHelper& get_class_helper()

--- a/mods/src/str_utils.h
+++ b/mods/src/str_utils.h
@@ -62,6 +62,13 @@ constexpr std::string AsciiStrToUpper(const std::string_view s)
   return str;
 }
 
+constexpr std::string AsciiStrToLower(const std::string_view s)
+{
+  std::string str = s.data();
+  std::ranges::transform(str, str.begin(), ::tolower);
+  return str;
+}
+
 constexpr std::vector<std::string> StrSplit(const std::string& input, const char delimiter)
 {
   std::vector<std::string> result;


### PR DESCRIPTION
## Per-faction bulk daily claim settings

### Background

The Daily Goals screen's "Claim All" toggle claims rewards for all factions at once. Players who only want to claim specific factions (e.g. only Federation) have no way to scope the bulk claim — they must either claim everything or claim each faction daily individually.

Additionally, the game resets the "Claim All" toggle to off on every restart, which is probably sensible for an all-faction bulk claim toggle. If we let players choose their faction, they may want to keep the toggle always on.

### What this PR adds

**`daily_bulk_claim_factions`** — a new config setting accepting a comma-separated list of factions (`federation`, `klingon`, `romulan`) that the Daily Goals "Claim All" toggle should be scoped to. When set:

- `MissionViewController.GetClaimableDailiesList` is hooked to filter out any claimable daily whose faction isn't in the configured list before the game builds its claimable list. Non-faction dailies are always left untouched.
- The three faction icons on the toggle (`Fed_Icon`, `Rom_Icon`, `Klg_Icon`) are shown/hidden via `GameObject.SetActive()` to match only the configured factions. Icons are restored to visible when the screen closes, since the widget may be pooled/reused by the game.
- Faction identity is resolved from `EventModel._factionPointRewards[i].ResourceSpec.resourceId_` (prefix `"Resource_FactionPoint_"`), read via plain field access only — no property or method calls on game objects.
- Empty list = no override; native game behaviour is untouched.

**`daily_bulk_claim_toggle_default_on`** — a new boolean config setting. When true, forces the "Claim All" toggle on the first time the Daily Goals screen is shown each session. The game itself always resets it to off on restart.

- Setting `Toggle.isOn` directly flips the underlying field but does not update the on-screen switch's visual state. Only a real click reliably produces the correct visual, so the toggle is forced on by simulating a click via `Toggle.OnPointerClick(PointerEventData)` — the same entry point Unity's EventSystem uses for a real mouse click.
- A simulated click can silently no-op if the toggle isn't yet interactable (e.g. during fade-in), so it is retried every frame from `ScreenManager_Update_Hook` until it succeeds, capped at 300 attempts (~5 seconds at 60fps).
- Once successfully forced on, it stops permanently for the session so the user can still manually toggle it off later without fighting the mod.

### How to verify

1. With `daily_bulk_claim_factions = ""` (default) — all factions claim as before, all three icons visible.
2. Set `daily_bulk_claim_factions = "federation"`, restart:
   - Only the Federation icon should be visible on the Claim All toggle.
   - Clicking Claim All should only claim Federation dailies (look for `filtering N claimable daily(ies) against configured factions [federation]` and `kept X/N daily(ies) for claiming` in debug logs).
3. Set `daily_bulk_claim_toggle_default_on = true`, restart:
   - The Claim All toggle should flip on automatically the first time the Daily Goals screen opens.
   - Manually toggling it off afterwards should stick — it only forces on once per session.

### Risks

- **`GetClaimableDailiesList` is hooked and mutates the returned list in-place** — the list is the game's own managed object, and `RemoveAt` is called on it. This is the same `IList` the game uses internally, so removing entries modifies what the game sees directly. This has been verified against real user data (pressed the real Claim All button with the filter active — claimed only the configured faction's dailies correctly).
- **Faction identity depends on `_factionPointRewards` being populated** — dailies without faction-point rewards are treated as non-faction dailies and always kept. If the game ever changes the reward structure, the filter would silently stop matching those dailies rather than claiming incorrectly.