### PR TITLE
Restore configurable double-tap Escape exit

### DIFF
--- a/example_community_patch_settings_da.toml
+++ b/example_community_patch_settings_da.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Forhindr "Escape" i at spørge, om spillet skal afsluttes
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ EKSPERIMENTELT: Forhindr den første pop op-reklame i at blive vist
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[========================================================================================================================================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/example_community_patch_settings_da.toml
+++ b/example_community_patch_settings_da.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Forhindr "Escape" i at spørge, om spillet skal afsluttes
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Verhindert, dass die Escape-Taste zum Beenden des Spiels auffordert
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Verhindert, dass die Escape-Taste zum Beenden des Spiels auffordert
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ EXPERIMENTELL: Verhindert das Erscheinen des ersten Werbe-Pop-ups
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[===================================================================================================================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/example_community_patch_settings_en-GB-x-cockney.toml
+++ b/example_community_patch_settings_en-GB-x-cockney.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_en-GB-x-cockney.toml
+++ b/example_community_patch_settings_en-GB-x-cockney.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ EXPERIMENTAL: Prevent the first popup advert from appearing
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[========================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/example_community_patch_settings_en-x-minionese.toml
+++ b/example_community_patch_settings_en-x-minionese.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_en-x-minionese.toml
+++ b/example_community_patch_settings_en-x-minionese.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ EXPERIMENTAL: Prevent the first popup advert from appearing
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[=============================================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Prevent "escape" from prompting to exit the game
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ EXPERIMENTAL: Prevent the first popup advert from appearing
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[========================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/example_community_patch_settings_es.toml
+++ b/example_community_patch_settings_es.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Impide que "Escape" pregunte si deseas salir del juego
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_es.toml
+++ b/example_community_patch_settings_es.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Impide que "Escape" pregunte si deseas salir del juego
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ EXPERIMENTAL: Impide que aparezca el primer anuncio emergente
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[==========================================================================================================================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Empêcher "échap" de proposer de quitter le jeu
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Empêcher "échap" de proposer de quitter le jeu
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ EXPÉRIMENTAL : Empêcher la première publicité pop-up d'apparaître
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[==========================================================================================================================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Zorgt ervoor dat het gebruiken van "escape" het spel niet sluit
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ EXPERIMENTEEL: Zorgt ervoor dat de eerste advertentie popup niet toont
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[===========================================================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Zorgt ervoor dat het gebruiken van "escape" het spel niet sluit
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_ru.toml
+++ b/example_community_patch_settings_ru.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Не показывать запрос выхода из игры при нажатии Escape
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_ru.toml
+++ b/example_community_patch_settings_ru.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Не показывать запрос выхода из игры при нажатии Escape
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ ЭКСПЕРИМЕНТАЛЬНО: Не показывать первое всплывающее рекламное окно
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[=====================================================================================================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/example_community_patch_settings_tlh.toml
+++ b/example_community_patch_settings_tlh.toml
@@ -596,7 +596,7 @@ auto_open_bulk_claim_flyout = false
 # Prevent "escape" vo' prompting Daq  exit  game
 disable_escape_exit = true
 
-# Max gap in ms for double-tap Escape to show the exit prompt.
+# Max gap in ms before a second Escape reaches the game's normal handling.
 # 0 = disabled; only applies when disable_escape_exit is true.
 escape_exit_timer = 0
 

--- a/example_community_patch_settings_tlh.toml
+++ b/example_community_patch_settings_tlh.toml
@@ -596,6 +596,10 @@ auto_open_bulk_claim_flyout = false
 # Prevent "escape" vo' prompting Daq  exit  game
 disable_escape_exit = true
 
+# Max gap in ms for double-tap Escape to show the exit prompt.
+# 0 = disabled; only applies when disable_escape_exit is true.
+escape_exit_timer = 0
+
 # ⚠️ ngong: Prevent  wa'DIch popup advert vo' appearing
 disable_first_popup = false
 
@@ -829,4 +833,3 @@ verify_ssl = true
 #  <[======================================================================================================]> 
 
 [sync.targets.spocksclub]
-

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -929,6 +929,8 @@ void Config::Load()
 
   this->disable_escape_exit =
       get_config_or_default(config, parsed, "ui", "disable_escape_exit", DCU::disable_escape_exit, write_config);
+  this->escape_exit_timer =
+      get_config_or_default(config, parsed, "ui", "escape_exit_timer", DCU::escape_exit_timer, write_config);
   this->disable_preview_locate =
       get_config_or_default(config, parsed, "ui", "disable_preview_locate", DCU::disable_preview_locate, write_config);
   this->disable_preview_recall =

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -190,6 +190,7 @@ public:
   bool disable_preview_locate;
   bool disable_preview_recall;
   bool disable_escape_exit;
+  int  escape_exit_timer;
   bool disable_galaxy_chat;
   bool disable_veil_chat;
   bool disable_first_popup;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -222,6 +222,9 @@ namespace UI
   constexpr const char* daily_bulk_claim_factions   = "";
   constexpr bool        daily_bulk_claim_toggle_default_on = false;
   constexpr bool        disable_escape_exit         = true;
+  // Maximum gap between Escape presses that opens the exit prompt.
+  // 0 disables double-tap and preserves the existing blocked behavior.
+  constexpr auto        escape_exit_timer           = 0;
   constexpr bool        disable_first_popup         = false;
   constexpr bool        disable_galaxy_chat         = false;
   constexpr bool        disable_move_keys           = false;

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -590,16 +590,25 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
   }
 
   if (config->disable_escape_exit && Key::Pressed(KeyCode::Escape)) {
-    // A second unhandled Escape inside the configured window falls through to
-    // the game's original handler and opens its normal exit prompt.
-    static auto escape_clock = std::chrono::steady_clock::time_point{};
-    const auto  escape_now   = std::chrono::steady_clock::now();
-    const auto  escape_diff  = std::chrono::duration_cast<std::chrono::milliseconds>(escape_now - escape_clock);
-    escape_clock             = escape_now;
-
-    if (config->escape_exit_timer <= 0 || escape_diff > std::chrono::milliseconds(config->escape_exit_timer)) {
+    // Keep suppressing a held key. Only distinct key-down edges participate in
+    // the double-tap window.
+    if (config->escape_exit_timer <= 0 || !Key::Down(KeyCode::Escape)) {
       return;
     }
+
+    static auto previous_escape_down = std::chrono::steady_clock::time_point{};
+    const auto  escape_now           = std::chrono::steady_clock::now();
+    const auto  escape_diff =
+        std::chrono::duration_cast<std::chrono::milliseconds>(escape_now - previous_escape_down);
+
+    if (previous_escape_down == std::chrono::steady_clock::time_point{}
+        || escape_diff > std::chrono::milliseconds(config->escape_exit_timer)) {
+      previous_escape_down = escape_now;
+      return;
+    }
+
+    // Consume the completed pair so a rapid third press starts a new one.
+    previous_escape_down = {};
   }
 
   // config->Load();

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -590,7 +590,16 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
   }
 
   if (config->disable_escape_exit && Key::Pressed(KeyCode::Escape)) {
-    return;
+    // A second unhandled Escape inside the configured window falls through to
+    // the game's original handler and opens its normal exit prompt.
+    static auto escape_clock = std::chrono::steady_clock::time_point{};
+    const auto  escape_now   = std::chrono::steady_clock::now();
+    const auto  escape_diff  = std::chrono::duration_cast<std::chrono::milliseconds>(escape_now - escape_clock);
+    escape_clock             = escape_now;
+
+    if (config->escape_exit_timer <= 0 || escape_diff > std::chrono::milliseconds(config->escape_exit_timer)) {
+      return;
+    }
   }
 
   // config->Load();


### PR DESCRIPTION
## Summary

Revives the behavior proposed in #124 on the current `dev` branch.

When `[ui].disable_escape_exit` is enabled:

- `escape_exit_timer = 0` preserves the existing behavior and blocks the game's exit prompt.
- A positive timer allows a second unhandled Escape press inside that many milliseconds to reach the game's normal exit handler.
- Escape presses consumed by mod UI/viewer handlers do not count toward the double-tap window.

The new option is documented in every localized example config. This replaces the closed PR rather than carrying its old branch history forward.

## Validation

- `py -3.12 scripts/validate-example-configs.py`
- `git diff --check`
- `xmake f -p windows -m release -y`
- `xmake -y mods`
- `xmake -y stfc-community-mod`
- Windows runtime smoke: deployed DLL hash matched the release build, the game loaded successfully, HotkeyHooks installed, and generated runtime vars resolved `disable_escape_exit = true` and `escape_exit_timer = 500`.

Manual Windows confirmation: a single unhandled Escape remained blocked, and a quick double-tap reached the game's normal exit flow successfully without a crash.
## Evidence-first review

- Base/merge: a4b8ca9358a830a734208a70914aeb58deacb2cf
- Reviewed head: 0be18e2b815eb163e47edfb381a67d2f64aaf050
- Diff hash: 057b7dba97990948ba004db91aae3962559dd934
- Receipt: 58fcaa3479fc7fb96a9a7efeb2ed868186b746cb79fbb99cd02e44114d736b42
- General, hostile, and independent implementation lanes found no confirmed source defect.
- The documentation correction passed an exact-head delta review.
- Local Windows release mods build, all 11 example-config validations, and git diff --check passed.

## Remaining evidence gaps

- exercise expired-window, held/repeat, rapid-triple, focused-input, viewer/reward-consumed, and scene-transition sequences
- smoke the native Escape behavior on macOS arm64 and x86_64
