### PR TITLE
Fix bulk-claim flyout reopening after reward presentation

### DIFF
--- a/mods/src/patches/parts/open_bulk_claim_gifts.cc
+++ b/mods/src/patches/parts/open_bulk_claim_gifts.cc
@@ -3,6 +3,7 @@
 
 #include <il2cpp/il2cpp_helper.h>
 #include <spud/detour.h>
+#include <spdlog/spdlog.h>
 
 #include <cstddef>
 
@@ -161,6 +162,7 @@ void InstallGiftsBulkClaimHooks()
   auto shop_list_scroller = ShopListScrollerViewController::ClassHelper();
   if (!shop_list_scroller.isValidHelper()) {
     ErrorMsg::MissingHelper("Digit.Prime.Shop", "ShopListScrollerViewController");
+    spdlog::warn("Skipping GiftsBulkClaimHooks: required IL2CPP dependencies are unavailable; no hooks installed.");
     return;
   }
 
@@ -188,6 +190,7 @@ void InstallGiftsBulkClaimHooks()
   }
 
   if (!can_install) {
+    spdlog::warn("Skipping GiftsBulkClaimHooks: required IL2CPP dependencies are unavailable; no hooks installed.");
     return;
   }
 

--- a/mods/src/patches/parts/open_bulk_claim_gifts.cc
+++ b/mods/src/patches/parts/open_bulk_claim_gifts.cc
@@ -100,17 +100,6 @@ void TryAutoOpenDrawer(ShopListScrollerViewController* controller)
   drawer->OpenViaButtonCallback();
 }
 
-void DrawerWidget_OnDidBindContext(auto original, DrawerWidget* self)
-{
-  original(self);
-
-  if (g_active_scroller != nullptr && g_active_scroller->SelectionDrawer() == self) {
-    // A new native selection-drawer binding represents a new in-place tab landing.
-    g_opened_for_landing = false;
-    TryAutoOpenDrawer(g_active_scroller);
-  }
-}
-
 void ShopListScrollerViewController_AboutToShow(auto original, ShopListScrollerViewController* self)
 {
   g_active_scroller    = self;
@@ -142,28 +131,30 @@ void ShopListScrollerViewController_UpdateDrawer(auto original, ShopListScroller
 
 void InstallGiftsBulkClaimHooks()
 {
+  bool can_install = true;
+
   auto drawer_context = DrawerContext::ClassHelper();
   if (!drawer_context.isValidHelper()) {
     ErrorMsg::MissingHelper("Prime.SharedFeatures.Scripts.UI.Widgets", "DrawerContext");
+    can_install = false;
   } else if (!drawer_context.GetField("Enabled").isValidHelper()) {
     ErrorMsg::MissingMethod("DrawerContext", "Enabled");
+    can_install = false;
   }
 
   auto drawer_widget = DrawerWidget::ClassHelper();
   if (!drawer_widget.isValidHelper()) {
     ErrorMsg::MissingHelper("Prime.SharedFeatures.Scripts.UI.Widgets", "DrawerWidget");
+    can_install = false;
   } else {
     auto widget_base = drawer_widget.GetParent("Widget`1");
     if (!widget_base.isValidHelper() || !widget_base.GetProperty("Context").isValidHelper()) {
       ErrorMsg::MissingMethod("DrawerWidget", "Widget<DrawerContext>.Context");
+      can_install = false;
     }
     if (drawer_widget.GetMethod("OnOpenButtonClicked") == nullptr) {
       ErrorMsg::MissingMethod("DrawerWidget", "OnOpenButtonClicked");
-    }
-    if (auto ptr = drawer_widget.GetMethod("OnDidBindContext"); ptr == nullptr) {
-      ErrorMsg::MissingMethod("DrawerWidget", "OnDidBindContext");
-    } else {
-      SPUD_STATIC_DETOUR(ptr, DrawerWidget_OnDidBindContext);
+      can_install = false;
     }
   }
 
@@ -175,23 +166,32 @@ void InstallGiftsBulkClaimHooks()
 
   if (!shop_list_scroller.GetField("_selectionDrawerWidget").isValidHelper()) {
     ErrorMsg::MissingMethod("ShopListScrollerViewController", "_selectionDrawerWidget");
+    can_install = false;
   }
 
-  if (auto ptr = shop_list_scroller.GetMethod("AboutToShow"); ptr == nullptr) {
+  auto about_to_show = shop_list_scroller.GetMethod("AboutToShow");
+  if (about_to_show == nullptr) {
     ErrorMsg::MissingMethod("ShopListScrollerViewController", "AboutToShow");
-  } else {
-    SPUD_STATIC_DETOUR(ptr, ShopListScrollerViewController_AboutToShow);
+    can_install = false;
   }
 
-  if (auto ptr = shop_list_scroller.GetMethod("AboutToHide"); ptr == nullptr) {
+  auto about_to_hide = shop_list_scroller.GetMethod("AboutToHide");
+  if (about_to_hide == nullptr) {
     ErrorMsg::MissingMethod("ShopListScrollerViewController", "AboutToHide");
-  } else {
-    SPUD_STATIC_DETOUR(ptr, ShopListScrollerViewController_AboutToHide);
+    can_install = false;
   }
 
-  if (auto ptr = shop_list_scroller.GetMethod("UpdateDrawer"); ptr == nullptr) {
+  auto update_drawer = shop_list_scroller.GetMethod("UpdateDrawer");
+  if (update_drawer == nullptr) {
     ErrorMsg::MissingMethod("ShopListScrollerViewController", "UpdateDrawer");
-  } else {
-    SPUD_STATIC_DETOUR(ptr, ShopListScrollerViewController_UpdateDrawer);
+    can_install = false;
   }
+
+  if (!can_install) {
+    return;
+  }
+
+  SPUD_STATIC_DETOUR(about_to_show, ShopListScrollerViewController_AboutToShow);
+  SPUD_STATIC_DETOUR(about_to_hide, ShopListScrollerViewController_AboutToHide);
+  SPUD_STATIC_DETOUR(update_drawer, ShopListScrollerViewController_UpdateDrawer);
 }

--- a/mods/src/patches/parts/open_bulk_claim_gifts.cc
+++ b/mods/src/patches/parts/open_bulk_claim_gifts.cc
@@ -1,24 +1,13 @@
 #include "config.h"
 #include "errormsg.h"
-#include "prime/Hub.h"
-#include "str_utils.h"
 
 #include <il2cpp/il2cpp_helper.h>
 #include <spud/detour.h>
 
 #include <cstddef>
-#include <cstring>
-#include <string>
 
 namespace
 {
-constexpr auto kGiftsCategoryKey    = "chests";
-constexpr int  kAutoOpenRetryFrames = 300;
-
-bool g_pending_auto_open   = false;
-bool g_auto_open_attempted = false;
-int  g_retry_frames_left   = 0;
-
 class DrawerContext
 {
 private:
@@ -31,9 +20,7 @@ private:
 
 public:
   static IL2CppClassHelper& ClassHelper()
-  {
-    return get_class_helper();
-  }
+  { return get_class_helper(); }
 
   bool Enabled()
   {
@@ -54,9 +41,7 @@ private:
 
 public:
   static IL2CppClassHelper& ClassHelper()
-  {
-    return get_class_helper();
-  }
+  { return get_class_helper(); }
 
   DrawerContext* Context()
   {
@@ -65,80 +50,12 @@ public:
     return field.GetRaw<DrawerContext>(this);
   }
 
-  bool ContextEnabled()
-  {
-    auto context = Context();
-    return context != nullptr && context->Enabled();
-  }
-
   void OpenViaButtonCallback()
   {
     static auto method = get_class_helper().GetMethod<void(DrawerWidget*)>("OnOpenButtonClicked");
     if (method != nullptr) {
       method(this);
     }
-  }
-};
-
-class ShopCategory
-{
-private:
-  static IL2CppClassHelper& get_class_helper()
-  {
-    static auto class_helper =
-        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.Prime.Shop", "ShopCategory");
-    return class_helper;
-  }
-
-public:
-  static IL2CppClassHelper& ClassHelper()
-  {
-    return get_class_helper();
-  }
-
-  static std::string KeyForValue(int value)
-  {
-    static auto method = get_class_helper().GetMethod<Il2CppString*(int)>("EnumToKey");
-    auto        key    = method != nullptr ? method(value) : nullptr;
-    return key != nullptr ? to_string(key) : std::string{};
-  }
-};
-
-class BundleGroupConfig
-{
-private:
-  static IL2CppClassHelper& get_class_helper()
-  {
-    static auto class_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Shop", "BundleGroupConfig");
-    return class_helper;
-  }
-
-public:
-  static IL2CppClassHelper& ClassHelper()
-  {
-    return get_class_helper();
-  }
-
-  int Category()
-  {
-    static auto field = get_class_helper().GetField("_category");
-    return field.isValidHelper() ? *(int*)((ptrdiff_t)this + field.offset()) : -1;
-  }
-};
-
-class ShopSectionContext
-{
-private:
-  static IL2CppClassHelper& get_class_helper()
-  {
-    static auto class_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Shop", "ShopSectionContext");
-    return class_helper;
-  }
-
-public:
-  static IL2CppClassHelper& ClassHelper()
-  {
-    return get_class_helper();
   }
 };
 
@@ -154,130 +71,72 @@ private:
 
 public:
   static IL2CppClassHelper& ClassHelper()
-  {
-    return get_class_helper();
-  }
+  { return get_class_helper(); }
 
   DrawerWidget* SelectionDrawer()
   {
-    // Lower Gifts << drawer; scroller category can describe upper shop chrome such as latinum.
     static auto field = get_class_helper().GetField("_selectionDrawerWidget");
     return field.isValidHelper() ? *(DrawerWidget**)((ptrdiff_t)this + field.offset()) : nullptr;
   }
 };
 
-bool IsClassNamed(void* object, const char* namespaze, const char* name)
-{
-  if (object == nullptr) {
-    return false;
-  }
-
-  const auto klass = ((Il2CppObject*)object)->klass;
-  if (klass == nullptr) {
-    return false;
-  }
-
-  const auto object_namespace = klass->namespaze != nullptr ? klass->namespaze : "";
-  return strcmp(object_namespace, namespaze) == 0 && strcmp(klass->name, name) == 0;
-}
-
-void ClearAutoOpen()
-{
-  g_pending_auto_open = false;
-  g_retry_frames_left = 0;
-}
-
-void ArmAutoOpen()
-{
-  g_pending_auto_open   = true;
-  g_auto_open_attempted = false;
-  g_retry_frames_left   = kAutoOpenRetryFrames;
-}
-
-bool IsGiftsShopPayload(int section, void* args)
-{
-  if (section != (int)SectionID::Shop_List || !IsClassNamed(args, "Digit.Prime.Shop", "BundleGroupConfig")) {
-    return false;
-  }
-
-  const auto category = ((BundleGroupConfig*)args)->Category();
-  return ShopCategory::KeyForValue(category) == kGiftsCategoryKey;
-}
-
-bool IsBulkClaimTabSection(int section)
-{
-  return section == (int)SectionID::Shop_List || section == (int)SectionID::Shop_AllianceChests
-         || section == (int)SectionID::Consumables || section == (int)SectionID::Missions_AwayTeamsList;
-}
+ShopListScrollerViewController* g_active_scroller    = nullptr;
+bool                            g_opened_for_landing = false;
 
 void TryAutoOpenDrawer(ShopListScrollerViewController* controller)
 {
-  if (!Config::Get().auto_open_bulk_claim_flyout || !g_pending_auto_open || g_auto_open_attempted
-      || controller == nullptr) {
+  if (!Config::Get().auto_open_bulk_claim_flyout || controller == nullptr || g_opened_for_landing) {
     return;
   }
 
-  if (g_retry_frames_left-- <= 0) {
-    ClearAutoOpen();
+  auto* drawer  = controller->SelectionDrawer();
+  auto* context = drawer != nullptr ? drawer->Context() : nullptr;
+  if (context == nullptr || !context->Enabled()) {
     return;
   }
 
-  auto drawer = controller->SelectionDrawer();
-  if (drawer == nullptr || !drawer->ContextEnabled()) {
-    return;
-  }
-
-  g_auto_open_attempted = true;
-  ClearAutoOpen();
+  // Mark first so a native callback cannot cause a nested lifecycle update to open the drawer twice.
+  g_opened_for_landing = true;
   drawer->OpenViaButtonCallback();
 }
 
-void ShopListViewController_AboutToHide(auto original, void* _this)
+void DrawerWidget_OnDidBindContext(auto original, DrawerWidget* self)
 {
-  ClearAutoOpen();
-  original(_this);
-}
+  original(self);
 
-void ShopListScrollerViewController_Update(auto original, ShopListScrollerViewController* _this)
-{
-  original(_this);
-  TryAutoOpenDrawer(_this);
-}
-
-void ShopSectionContext_InjectTabData(auto original, ShopSectionContext* _this, int section,
-                                      Il2CppArraySize* tab_locale_contexts,
-                                      Il2CppArraySize* additional_tab_locale_contexts,
-                                      Il2CppArraySize* tab_icon_identifiers, Il2CppArraySize* pip_types,
-                                      Il2CppArraySize* hide_if_no_content, bool set_current_section,
-                                      bool override_existing_tabs)
-{
-  original(_this, section, tab_locale_contexts, additional_tab_locale_contexts, tab_icon_identifiers, pip_types,
-           hide_if_no_content, set_current_section, override_existing_tabs);
-
-  if (!Config::Get().auto_open_bulk_claim_flyout || !set_current_section) {
-    return;
-  }
-
-  if (IsBulkClaimTabSection(section)) {
-    ArmAutoOpen();
-  } else {
-    ClearAutoOpen();
+  if (g_active_scroller != nullptr && g_active_scroller->SelectionDrawer() == self) {
+    // A new native selection-drawer binding represents a new in-place tab landing.
+    g_opened_for_landing = false;
+    TryAutoOpenDrawer(g_active_scroller);
   }
 }
 
-bool SectionManager_TriggerSectionChange(auto original,
-                                         void* _this,
-                                         int next_section,
-                                         void* args,
-                                         bool forced_section_change,
-                                         bool is_go_back_step,
-                                         bool allow_same_section)
+void ShopListScrollerViewController_AboutToShow(auto original, ShopListScrollerViewController* self)
 {
-  const auto changed = original(_this, next_section, args, forced_section_change, is_go_back_step, allow_same_section);
-  if (changed && Config::Get().auto_open_bulk_claim_flyout && IsGiftsShopPayload(next_section, args)) {
-    ArmAutoOpen();
+  g_active_scroller    = self;
+  g_opened_for_landing = false;
+
+  original(self);
+  TryAutoOpenDrawer(self);
+}
+
+void ShopListScrollerViewController_AboutToHide(auto original, ShopListScrollerViewController* self)
+{
+  if (g_active_scroller == self) {
+    g_active_scroller    = nullptr;
+    g_opened_for_landing = false;
   }
-  return changed;
+
+  original(self);
+}
+
+void ShopListScrollerViewController_UpdateDrawer(auto original, ShopListScrollerViewController* self)
+{
+  original(self);
+
+  if (g_active_scroller == self) {
+    TryAutoOpenDrawer(self);
+  }
 }
 } // namespace
 
@@ -301,60 +160,38 @@ void InstallGiftsBulkClaimHooks()
     if (drawer_widget.GetMethod("OnOpenButtonClicked") == nullptr) {
       ErrorMsg::MissingMethod("DrawerWidget", "OnOpenButtonClicked");
     }
-  }
-
-  auto shop_category = ShopCategory::ClassHelper();
-  if (!shop_category.isValidHelper()) {
-    ErrorMsg::MissingHelper("Digit.Prime.Shop", "ShopCategory");
-  } else if (shop_category.GetMethod("EnumToKey") == nullptr) {
-    ErrorMsg::MissingMethod("ShopCategory", "EnumToKey");
-  }
-
-  auto bundle_group_config = BundleGroupConfig::ClassHelper();
-  if (!bundle_group_config.isValidHelper()) {
-    ErrorMsg::MissingHelper("Digit.Prime.Shop", "BundleGroupConfig");
-  } else if (!bundle_group_config.GetField("_category").isValidHelper()) {
-    ErrorMsg::MissingMethod("BundleGroupConfig", "_category");
-  }
-
-  auto shop_section_context = ShopSectionContext::ClassHelper();
-  if (!shop_section_context.isValidHelper()) {
-    ErrorMsg::MissingHelper("Digit.Prime.Shop", "ShopSectionContext");
-  } else if (auto ptr = shop_section_context.GetMethod("InjectTabData"); ptr == nullptr) {
-    ErrorMsg::MissingMethod("ShopSectionContext", "InjectTabData");
-  } else {
-    SPUD_STATIC_DETOUR(ptr, ShopSectionContext_InjectTabData);
-  }
-
-  auto shop_list_controller = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Shop", "ShopListViewController");
-  if (!shop_list_controller.isValidHelper()) {
-    ErrorMsg::MissingHelper("Digit.Prime.Shop", "ShopListViewController");
-  } else if (auto ptr = shop_list_controller.GetMethod("AboutToHide"); ptr == nullptr) {
-    ErrorMsg::MissingMethod("ShopListViewController", "AboutToHide");
-  } else {
-    SPUD_STATIC_DETOUR(ptr, ShopListViewController_AboutToHide);
+    if (auto ptr = drawer_widget.GetMethod("OnDidBindContext"); ptr == nullptr) {
+      ErrorMsg::MissingMethod("DrawerWidget", "OnDidBindContext");
+    } else {
+      SPUD_STATIC_DETOUR(ptr, DrawerWidget_OnDidBindContext);
+    }
   }
 
   auto shop_list_scroller = ShopListScrollerViewController::ClassHelper();
   if (!shop_list_scroller.isValidHelper()) {
     ErrorMsg::MissingHelper("Digit.Prime.Shop", "ShopListScrollerViewController");
-  } else {
-    if (!shop_list_scroller.GetField("_selectionDrawerWidget").isValidHelper()) {
-      ErrorMsg::MissingMethod("ShopListScrollerViewController", "_selectionDrawerWidget");
-    }
-    if (auto ptr = shop_list_scroller.GetMethod("Update"); ptr == nullptr) {
-      ErrorMsg::MissingMethod("ShopListScrollerViewController", "Update");
-    } else {
-      SPUD_STATIC_DETOUR(ptr, ShopListScrollerViewController_Update);
-    }
+    return;
   }
 
-  auto section_manager = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Sections", "SectionManager");
-  if (!section_manager.isValidHelper()) {
-    ErrorMsg::MissingHelper("Digit.Client.Sections", "SectionManager");
-  } else if (auto ptr = section_manager.GetMethod("TriggerSectionChange", 5); ptr == nullptr) {
-    ErrorMsg::MissingMethod("SectionManager", "TriggerSectionChange(section,args)");
+  if (!shop_list_scroller.GetField("_selectionDrawerWidget").isValidHelper()) {
+    ErrorMsg::MissingMethod("ShopListScrollerViewController", "_selectionDrawerWidget");
+  }
+
+  if (auto ptr = shop_list_scroller.GetMethod("AboutToShow"); ptr == nullptr) {
+    ErrorMsg::MissingMethod("ShopListScrollerViewController", "AboutToShow");
   } else {
-    SPUD_STATIC_DETOUR(ptr, SectionManager_TriggerSectionChange);
+    SPUD_STATIC_DETOUR(ptr, ShopListScrollerViewController_AboutToShow);
+  }
+
+  if (auto ptr = shop_list_scroller.GetMethod("AboutToHide"); ptr == nullptr) {
+    ErrorMsg::MissingMethod("ShopListScrollerViewController", "AboutToHide");
+  } else {
+    SPUD_STATIC_DETOUR(ptr, ShopListScrollerViewController_AboutToHide);
+  }
+
+  if (auto ptr = shop_list_scroller.GetMethod("UpdateDrawer"); ptr == nullptr) {
+    ErrorMsg::MissingMethod("ShopListScrollerViewController", "UpdateDrawer");
+  } else {
+    SPUD_STATIC_DETOUR(ptr, ShopListScrollerViewController_UpdateDrawer);
   }
 }


### PR DESCRIPTION
## Summary

- drive automatic bulk-claim flyout opening from the native shop-list lifecycle instead of inferred navigation payloads
- reopen the enabled selection drawer when returning from reward presentation
- retain one automatic open per visible landing so manual closure is respected for the rest of that visit
- remove the per-frame update detour, 300-frame retry window, hardcoded section allowlist, category/payload conversion, and generic drawer-bind detour
- resolve every required field, property, callback, and lifecycle method before installing the three scroller detours, failing closed on IL2CPP drift

The native `DrawerContext.Enabled` flag is intentionally the eligibility predicate: opted-in users get automatic opening wherever the game exposes an enabled bulk-selection drawer rather than only through enumerated navigation paths.

## Runtime evidence

With `always_skip_reveal_sequence = false`, bulk claimed from Gifts, completed reward presentation, and returned to the shop; the flyout reopened successfully. Manually closing it during the visit left it closed.

Corrected head `4f045c0` was built and deployed with `ax cycle --BuildMode releasedbg`; build and deployed DLL hashes matched at `3782AAA8429D7AD338B5EA774BEB47667D5EE8B767A482DB59EAE3C6AA5C3191`, all required hooks resolved, and boot completed without mod errors. The target-flow smoke above was performed before the final safety-only removal of the generic drawer-bind detour.

A temporary diagnostic-only tab trace caused a client crash during development and was fully removed before either PR commit.

## Review gate

Evidence-first general, hostile, and independent lanes reviewed receipt-bound head `4f045c0` / diff `f200f3719249949228e00b0aad73c1e642a0d00a`. The generic bind hook and partial-install drift risk were corrected in `4f045c0`; full correction re-review found no remaining confirmed defect. The remaining disclosed risk is runtime coverage outside Gifts for the intentionally native-enabled eligibility scope.

## Validation

- `git diff --check`
- Windows releasedbg `mods` build
- Windows release `mods` build
- exact-head releasedbg deploy/hash/clean boot
- GitHub Actions: Windows build, macOS arm64 build, macOS x86_64 build, macOS package, and example-config validation all passed

## Platform note

The documented local macOS command currently fails during XMake option parsing because this checkout does not define `--target_minver`; macOS compile/package validation comes from CI, and macOS runtime behavior remains untested.