### PR TITLE
fix: de-butt planet Ferri

### DIFF
--- a/example_community_patch_settings_da.toml
+++ b/example_community_patch_settings_da.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Fastgør konfigurerede skibe forrest i flådestyringsdokken
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Konfigurierte Schiffe im Flottenmanagement-Dock an den Anfang stellen
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/example_community_patch_settings_en-GB-x-cockney.toml
+++ b/example_community_patch_settings_en-GB-x-cockney.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Pin configured ships to the front of the fleet management dock
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/example_community_patch_settings_en-x-minionese.toml
+++ b/example_community_patch_settings_en-x-minionese.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Pin configured ships to the front of the fleet management dock
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Pin configured ships to the front of the fleet management dock
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/example_community_patch_settings_es.toml
+++ b/example_community_patch_settings_es.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Fija las naves configuradas al principio del muelle de gestión de flota
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Place les vaisseaux configurés en tête du quai de gestion de flotte
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Zet geconfigureerde schepen vooraan in het vlootbeheerdok
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/example_community_patch_settings_ru.toml
+++ b/example_community_patch_settings_ru.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Помещает настроенные корабли в начало списка в окне управления флотом
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/example_community_patch_settings_tlh.toml
+++ b/example_community_patch_settings_tlh.toml
@@ -244,6 +244,7 @@ panhooks = true
 # Pin configured ships to the front of the fleet management dock
 pinnedshiphooks = true
 syncpatches = true
+systemviewhooks = true
 tempcrashfixes = true
 testpatches = true
 toastbannerhooks = true

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -858,6 +858,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "patches", "officersorthooks", DCP::officersorthooks, write_config);
   this->installPinnedShipSortHooks =
       get_config_or_default(config, parsed, "patches", "pinnedshiphooks", DCP::pinnedshiphooks, write_config);
+  this->installSystemViewHooks =
+      get_config_or_default(config, parsed, "patches", "systemviewhooks", DCP::systemviewhooks, write_config);
   spdlog::debug("");
   this->queue_enabled =
       get_config_or_default(config, parsed, "control", "queue_enabled", DCC::queue_enabled, write_config);

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -278,4 +278,6 @@ public:
 
   // Fleet management dock ship sort: pin configured ships to the front
   bool installPinnedShipSortHooks;
+
+  bool installSystemViewHooks;
 };

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -87,6 +87,7 @@ namespace Patches
   constexpr bool cargoformathooks           = true;  // on by default: cargo number precision override
   constexpr bool officersorthooks           = true;  // restore Below Deck Ability sort option
   constexpr bool pinnedshiphooks            = true;  // pin configured ships to front of fleet dock sort
+  constexpr bool systemviewhooks            = true;  // auto-hide duplicate planets/objects in the system view
 } // namespace Patches
 
 namespace Shortcuts

--- a/mods/src/patches/parts/system_view.cc
+++ b/mods/src/patches/parts/system_view.cc
@@ -1,0 +1,216 @@
+#include "errormsg.h"
+
+#include <il2cpp/il2cpp-functions.h>
+#include <il2cpp/il2cpp_helper.h>
+#include <spud/detour.h>
+
+#include <cmath>
+#include <cstdint>
+#include <mutex>
+#include <unordered_set>
+#include <vector>
+
+namespace
+{
+constexpr float kDedupeDistance = 25.0f;
+
+struct SlotObject
+{
+  void* klass;
+  void* monitor;
+  void* unknownFields;
+  float x;
+  float y;
+};
+
+struct TreeNodeView
+{
+  void*       klass;
+  void*       monitor;
+  void*       address;
+  void*       attributes;
+  int64_t     id;
+  int64_t     parentNullable[2];
+  int32_t     type;
+  SlotObject* coords;
+};
+
+struct PlanetIconDataView
+{
+  void*   klass;
+  void*   monitor;
+  int64_t planet_id;
+};
+
+struct CreatedObject
+{
+  void*   resource;
+  float   x;
+  float   y;
+  void*   game_object;
+  int64_t node_id;
+};
+
+std::mutex                 s_mutex;
+std::vector<CreatedObject> s_created;
+std::unordered_set<int64_t> s_deduped_node_ids;
+
+void (*s_set_active)(void* game_object, bool value) = nullptr;
+void* (*s_get_game_object)(void* component)         = nullptr;
+const MethodInfo* s_get_context                     = nullptr;
+
+void* s_last_created_go = nullptr;
+
+void Deactivate(void* game_object)
+{
+  if (game_object != nullptr && s_set_active != nullptr) {
+    s_set_active(game_object, false);
+  }
+}
+
+void HandleCreated(const TreeNodeView* node, const void* resource)
+{
+  if (node == nullptr || node->coords == nullptr || resource == nullptr) {
+    s_last_created_go = nullptr;
+    return;
+  }
+
+  const std::lock_guard<std::mutex> lock(s_mutex);
+
+  for (auto it = s_created.begin(); it != s_created.end(); ++it) {
+    if (it->resource != resource) {
+      continue;
+    }
+    const auto dx = node->coords->x - it->x;
+    const auto dy = node->coords->y - it->y;
+    if (dx * dx + dy * dy < kDedupeDistance * kDedupeDistance) {
+      Deactivate(it->game_object);
+      s_deduped_node_ids.insert(it->node_id);
+      *it = CreatedObject{const_cast<void*>(resource), node->coords->x, node->coords->y, s_last_created_go, node->id};
+      s_last_created_go = nullptr;
+      return;
+    }
+  }
+
+  s_created.push_back(
+      CreatedObject{const_cast<void*>(resource), node->coords->x, node->coords->y, s_last_created_go, node->id});
+  s_last_created_go = nullptr;
+}
+
+void PlanetViewUtils_Populate_Hook(auto original, void* _this, void* system, int64_t nodeId, int32_t depth)
+{
+  {
+    const std::lock_guard<std::mutex> lock(s_mutex);
+    s_created.clear();
+    s_deduped_node_ids.clear();
+  }
+  original(_this, system, nodeId, depth);
+}
+
+void PlanetViewUtils_CreateGameObjectAndBlock_Hook(auto original, void* _this, void** go, void* resource, void** block)
+{
+  s_last_created_go = nullptr;
+  original(_this, go, resource, block);
+  s_last_created_go = go != nullptr ? *go : nullptr;
+}
+
+void PlanetViewUtils_CreateCelestialBody_Hook(auto original, void* _this, TreeNodeView* node, void* resource,
+                                              bool usingDefault)
+{
+  s_last_created_go = nullptr;
+  original(_this, node, resource, usingDefault);
+  HandleCreated(node, resource);
+}
+
+void PlanetViewUtils_CreateEntity_Hook(auto original, void* _this, TreeNodeView* node, void* resource,
+                                       bool usingDefault, Il2CppString* entityName)
+{
+  s_last_created_go = nullptr;
+  original(_this, node, resource, usingDefault, entityName);
+  HandleCreated(node, resource);
+}
+
+void NavigationPlanetWidget_OnDidBindContext_Hook(auto original, void* _this)
+{
+  original(_this);
+
+  if (s_get_context == nullptr) {
+    return;
+  }
+
+  Il2CppException* exc  = nullptr;
+  auto*            data = reinterpret_cast<PlanetIconDataView*>(il2cpp_runtime_invoke(s_get_context, _this, nullptr, &exc));
+  if (exc != nullptr || data == nullptr) {
+    return;
+  }
+
+  bool deduped = false;
+  {
+    const std::lock_guard<std::mutex> lock(s_mutex);
+    deduped = s_deduped_node_ids.find(data->planet_id) != s_deduped_node_ids.end();
+  }
+
+  if (deduped) {
+    Deactivate(s_get_game_object != nullptr ? s_get_game_object(_this) : nullptr);
+  }
+}
+} // namespace
+
+void InstallSystemViewHooks()
+{
+  static auto game_object_helper = il2cpp_get_class_helper("UnityEngine.CoreModule", "UnityEngine", "GameObject");
+  if (game_object_helper.isValidHelper()) {
+    s_set_active = game_object_helper.GetMethod<void(void*, bool)>("SetActive", 1);
+  }
+
+  static auto component_helper = il2cpp_get_class_helper("UnityEngine.CoreModule", "UnityEngine", "Component");
+  if (component_helper.isValidHelper()) {
+    s_get_game_object = component_helper.GetMethod<void*(void*)>("get_gameObject", 0);
+  }
+
+  static auto planet_view_utils =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Navigation", "PlanetViewUtils");
+  if (!planet_view_utils.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.Prime.Navigation", "PlanetViewUtils");
+    return;
+  }
+
+  static auto planet_widget_helper =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Navigation", "NavigationPlanetWidget");
+  if (!planet_widget_helper.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.Prime.Navigation", "NavigationPlanetWidget");
+    return;
+  }
+
+  s_get_context = planet_widget_helper.GetMethodInfo("get_Context", 0);
+
+  if (const auto ptr = planet_view_utils.GetMethod("Populate", 3); ptr != nullptr) {
+    SPUD_STATIC_DETOUR(ptr, PlanetViewUtils_Populate_Hook);
+  } else {
+    ErrorMsg::MissingMethod("PlanetViewUtils", "Populate");
+  }
+
+  if (const auto ptr = planet_view_utils.GetMethod("CreateGameObjectAndBlock", 3); ptr != nullptr) {
+    SPUD_STATIC_DETOUR(ptr, PlanetViewUtils_CreateGameObjectAndBlock_Hook);
+  } else {
+    ErrorMsg::MissingMethod("PlanetViewUtils", "CreateGameObjectAndBlock");
+  }
+
+  if (const auto ptr = planet_view_utils.GetMethod("CreateCelestialBody", 3); ptr != nullptr) {
+    SPUD_STATIC_DETOUR(ptr, PlanetViewUtils_CreateCelestialBody_Hook);
+  } else {
+    ErrorMsg::MissingMethod("PlanetViewUtils", "CreateCelestialBody");
+  }
+
+  if (const auto ptr = planet_view_utils.GetMethod("CreateEntity", 4); ptr != nullptr) {
+    SPUD_STATIC_DETOUR(ptr, PlanetViewUtils_CreateEntity_Hook);
+  } else {
+    ErrorMsg::MissingMethod("PlanetViewUtils", "CreateEntity");
+  }
+
+  if (const auto ptr = planet_widget_helper.GetMethod("OnDidBindContext", 0); ptr != nullptr) {
+    SPUD_STATIC_DETOUR(ptr, NavigationPlanetWidget_OnDidBindContext_Hook);
+  } else {
+    ErrorMsg::MissingMethod("NavigationPlanetWidget", "OnDidBindContext");
+  }
+}

--- a/mods/src/patches/parts/system_view.cc
+++ b/mods/src/patches/parts/system_view.cc
@@ -12,7 +12,8 @@
 
 namespace
 {
-constexpr float kDedupeDistance = 25.0f;
+constexpr int64_t kDedupeSystemParentId = 1836706599;
+constexpr float   kDedupeDistance      = 75.0f;
 
 struct SlotObject
 {
@@ -30,7 +31,8 @@ struct TreeNodeView
   void*       address;
   void*       attributes;
   int64_t     id;
-  int64_t     parentNullable[2];
+  uint8_t     parent_has_value;
+  int64_t     parent_id;
   int32_t     type;
   SlotObject* coords;
 };
@@ -44,9 +46,8 @@ struct PlanetIconDataView
 
 struct CreatedObject
 {
-  void*   resource;
-  float   x;
-  float   y;
+  float    x;
+  float    y;
   void*   game_object;
   int64_t node_id;
 };
@@ -68,9 +69,10 @@ void Deactivate(void* game_object)
   }
 }
 
-void HandleCreated(const TreeNodeView* node, const void* resource)
+void HandleCreated(const TreeNodeView* node)
 {
-  if (node == nullptr || node->coords == nullptr || resource == nullptr) {
+  if (node == nullptr || node->coords == nullptr || node->parent_has_value == 0 ||
+      node->parent_id != kDedupeSystemParentId) {
     s_last_created_go = nullptr;
     return;
   }
@@ -78,22 +80,18 @@ void HandleCreated(const TreeNodeView* node, const void* resource)
   const std::lock_guard<std::mutex> lock(s_mutex);
 
   for (auto it = s_created.begin(); it != s_created.end(); ++it) {
-    if (it->resource != resource) {
-      continue;
-    }
     const auto dx = node->coords->x - it->x;
     const auto dy = node->coords->y - it->y;
     if (dx * dx + dy * dy < kDedupeDistance * kDedupeDistance) {
       Deactivate(it->game_object);
       s_deduped_node_ids.insert(it->node_id);
-      *it = CreatedObject{const_cast<void*>(resource), node->coords->x, node->coords->y, s_last_created_go, node->id};
+      *it = CreatedObject{node->coords->x, node->coords->y, s_last_created_go, node->id};
       s_last_created_go = nullptr;
       return;
     }
   }
 
-  s_created.push_back(
-      CreatedObject{const_cast<void*>(resource), node->coords->x, node->coords->y, s_last_created_go, node->id});
+  s_created.push_back(CreatedObject{node->coords->x, node->coords->y, s_last_created_go, node->id});
   s_last_created_go = nullptr;
 }
 
@@ -115,19 +113,11 @@ void PlanetViewUtils_CreateGameObjectAndBlock_Hook(auto original, void* _this, v
 }
 
 void PlanetViewUtils_CreateCelestialBody_Hook(auto original, void* _this, TreeNodeView* node, void* resource,
-                                              bool usingDefault)
+                                               bool usingDefault)
 {
   s_last_created_go = nullptr;
   original(_this, node, resource, usingDefault);
-  HandleCreated(node, resource);
-}
-
-void PlanetViewUtils_CreateEntity_Hook(auto original, void* _this, TreeNodeView* node, void* resource,
-                                       bool usingDefault, Il2CppString* entityName)
-{
-  s_last_created_go = nullptr;
-  original(_this, node, resource, usingDefault, entityName);
-  HandleCreated(node, resource);
+  HandleCreated(node);
 }
 
 void NavigationPlanetWidget_OnDidBindContext_Hook(auto original, void* _this)
@@ -200,12 +190,6 @@ void InstallSystemViewHooks()
     SPUD_STATIC_DETOUR(ptr, PlanetViewUtils_CreateCelestialBody_Hook);
   } else {
     ErrorMsg::MissingMethod("PlanetViewUtils", "CreateCelestialBody");
-  }
-
-  if (const auto ptr = planet_view_utils.GetMethod("CreateEntity", 4); ptr != nullptr) {
-    SPUD_STATIC_DETOUR(ptr, PlanetViewUtils_CreateEntity_Hook);
-  } else {
-    ErrorMsg::MissingMethod("PlanetViewUtils", "CreateEntity");
   }
 
   if (const auto ptr = planet_widget_helper.GetMethod("OnDidBindContext", 0); ptr != nullptr) {

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -48,6 +48,7 @@ void InstallDoubleClickAssignShipHooks();
 void InstallInstantWarpConfirmationHooks();
 void InstallForbiddenTechConfirmationHooks();
 void InstallAudioEventHooks();
+void InstallSystemViewHooks();
 
 __int64 il2cpp_init_hook(auto original, const char* domain_name)
 {
@@ -151,6 +152,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"InstantWarpConfirm",   {InstallInstantWarpConfirmationHooks, &cfg.installInstantWarpConfirmationHooks}},
       {"ForbiddenTechConfirm", {InstallForbiddenTechConfirmationHooks, &cfg.auto_confirm_ft_upgrade}},
       {"AudioEvents",          {InstallAudioEventHooks,                 &cfg.installAudioEventHooks}},
+      {"SystemViewHooks",     {InstallSystemViewHooks,         &cfg.installSystemViewHooks}},
   };
   printf("il2cpp_init_hook(%s)\n", domain_name);
 


### PR DESCRIPTION
Panda's system contains duplicate planet nodes for the Kulgan and Ferri planets:

- Pair 1: `(556, -49)` and `(535, -52)` — 21 slot units apart, same asset instance
- Pair 2: `(-249, 471)` and `(-194, 474)` — 55 slot units apart, two *separate*
  instances of the same visual (different `Object` pointers)

One side effect is poor Ferri's planet looking like a giant space butt 🍑 😂 I have no idea why they would send the planets twice or why they won't clean it up but we can filter it client-side.

The system view builds all of this through `Digit.Prime.Navigation.PlanetViewUtils`:

- `Populate(NodeSystem, long, NodeDepth)` spawns the system's contents
- `CreateCelestialBody` instantiates each body (via the nested
  `CreateGameObjectAndBlock`)
- `NavigationPlanetWidget` renders the floating planet label per body

### How this PR fixes it

Adds a new patch, `SystemViewHooks` (standard `[patches]` toggle
`systemviewhooks`, default `true`), scoped to that single system to avoid side effects elsewhere:

- Dedupe applies only to bodies whose `TreeNode.ParentID` equals
  the affected system's node ID. Each planet carries its system's ID in its
  own data, so the check is immune to spawn ordering: bodies are created from
  async asset-load callbacks 300–400 ms after `Populate` returns, and
  `PlanetViewUtils` interleaves populates for cached neighbouring systems —
  a gate keyed on the `Populate` argument is disarmed before the bodies exist.
  All other systems are untouched.
- `Populate` is hooked to reset the per-system tracking state.
- `CreateGameObjectAndBlock` is hooked to capture the freshly created
  `GameObject` (called synchronously inside every `Create*` method).
- `CreateCelestialBody` tracks every created body of that system (slot
  coordinates, GameObject, TreeNode ID). When a newly created body lands
  **within 75 slot units** of an already-tracked one, the *earlier* object is
  deactivated via `GameObject.SetActive(false)` and the newly spawned one is
  kept — the later-spawned node is the one game interactions bind to, so the
  visible planet stays fully clickable (verified in-game).
- `NavigationPlanetWidget.OnDidBindContext` is hooked to deactivate the
  duplicate's label widget (bound planet ID resolved through
  `Widget<PlanetIconData>.get_Context`, checked against the deduped set), so
  the name label disappears along with its planet.

- **Objects are never prevented from being created.** `PlanetViewUtils` counts
  every requested object (`_expectedElementCount` / `OnCallbackCheck`) and only
  completes the populate sequence once all of them exist — skipping a create
  call leaves the system view loading forever. Every create runs normally and
  only the redundant GameObject is switched off afterwards.
- **The label widget is hidden, not destroyed.** The widget pool re-activates
  roots on reuse, so deactivating the widget root cannot leak a disabled state
  onto a different planet later.

### How to verify

1. Enter the Pandapirate system. Before: two planets render doubled at slight
   offsets, each with two labels.
2. With the patch: one planet per location, one label each, and both surviving
   planets respond normally to clicks and interactions (missions, mining,
   docking).

### Risks

- **Hardcoded single-system scope.** The system node ID and the 75-unit
  threshold are constants in the patch; this is a targeted fix for one
  system's data, not a general mechanism. If the game data for that system
  changes, the constants may need adjusting.
- **The hidden duplicates still exist server-side.** Gameplay data attached to
  the deactivated nodes is unaffected — only their visuals
  are suppressed.