### PR TITLE
Arbitrate modified directional hotkeys

### DIFF
--- a/mods/src/patches/key.cc
+++ b/mods/src/patches/key.cc
@@ -10,8 +10,19 @@
 int Key::cacheInputFocused  = 0;
 int Key::cacheInputModified = 0;
 
-std::array<int, (int)KeyCode::Max> Key::cacheKeyPressed = {};
-std::array<int, (int)KeyCode::Max> Key::cacheKeyDown    = {};
+std::array<int, (int)KeyCode::Max>  Key::cacheKeyPressed         = {};
+std::array<int, (int)KeyCode::Max>  Key::cacheKeyDown            = {};
+std::array<bool, (int)KeyCode::Max> Key::claimedDirectionalInput = {};
+
+namespace
+{
+constexpr std::array directionalKeys = {
+    KeyCode::LeftArrow,
+    KeyCode::RightArrow,
+    KeyCode::UpArrow,
+    KeyCode::DownArrow,
+};
+}
 
 const std::unordered_map<std::string, KeyCode> Key::mappedKeys = {
     {"LALT", KeyCode::LeftAlt},
@@ -193,6 +204,39 @@ bool Key::IsModifier(KeyCode key)
   }
 }
 
+void Key::ClaimDirectionalInput(KeyCode key)
+{
+  switch (key) {
+    case KeyCode::LeftArrow:
+    case KeyCode::RightArrow:
+    case KeyCode::UpArrow:
+    case KeyCode::DownArrow:
+      claimedDirectionalInput[(int)key] = true;
+      break;
+    default:
+      break;
+  }
+}
+
+bool Key::IsDirectionalInputClaimed()
+{
+  auto claimed = false;
+  for (const auto key : directionalKeys) {
+    auto& directionClaimed = claimedDirectionalInput[(int)key];
+    if (!directionClaimed) {
+      continue;
+    }
+
+    if (Pressed(key)) {
+      claimed = true;
+    } else {
+      directionClaimed = false;
+    }
+  }
+
+  return claimed;
+}
+
 bool Key::IsModified()
 {
   if (cacheInputModified == 0) {
@@ -215,6 +259,15 @@ void Key::ResetCache()
   for (int i = 0; i < (int)KeyCode::Max; i++) {
     Key::cacheKeyDown[i]    = 0;
     Key::cacheKeyPressed[i] = 0;
+  }
+
+  // Direction claims span frames while their key is held so one-shot chords cannot leak into native movement.
+  // Prune them here as well as at the consumer so claims cannot survive a scene without NavigationPan.
+  for (const auto key : directionalKeys) {
+    auto& directionClaimed = claimedDirectionalInput[(int)key];
+    if (directionClaimed && !Pressed(key)) {
+      directionClaimed = false;
+    }
   }
 }
 bool Key::Down(KeyCode key)

--- a/mods/src/patches/key.cc
+++ b/mods/src/patches/key.cc
@@ -9,6 +9,7 @@
 
 int Key::cacheInputFocused  = 0;
 int Key::cacheInputModified = 0;
+int Key::cacheFrame         = -1;
 
 std::array<int, (int)KeyCode::Max>  Key::cacheKeyPressed         = {};
 std::array<int, (int)KeyCode::Max>  Key::cacheKeyDown            = {};
@@ -22,6 +23,12 @@ constexpr std::array directionalKeys = {
     KeyCode::UpArrow,
     KeyCode::DownArrow,
 };
+
+int CurrentInputFrame()
+{
+  static auto GetFrameCount = il2cpp_resolve_icall_typed<int()>("UnityEngine.Time::get_frameCount()");
+  return GetFrameCount();
+}
 }
 
 const std::unordered_map<std::string, KeyCode> Key::mappedKeys = {
@@ -220,6 +227,8 @@ void Key::ClaimDirectionalInput(KeyCode key)
 
 bool Key::IsDirectionalInputClaimed()
 {
+  EnsureCurrentFrame();
+
   auto claimed = false;
   for (const auto key : directionalKeys) {
     auto& directionClaimed = claimedDirectionalInput[(int)key];
@@ -239,6 +248,8 @@ bool Key::IsDirectionalInputClaimed()
 
 bool Key::IsModified()
 {
+  EnsureCurrentFrame();
+
   if (cacheInputModified == 0) {
     cacheInputModified = -1;
     if (Key::Pressed(KeyCode::LeftAlt) || Key::Pressed(KeyCode::LeftControl) || Key::Pressed(KeyCode::LeftShift)
@@ -254,6 +265,7 @@ bool Key::IsModified()
 
 void Key::ResetCache()
 {
+  Key::cacheFrame          = CurrentInputFrame();
   Key::cacheInputFocused  = 0;
   Key::cacheInputModified = 0;
   for (int i = 0; i < (int)KeyCode::Max; i++) {
@@ -270,8 +282,18 @@ void Key::ResetCache()
     }
   }
 }
+
+void Key::EnsureCurrentFrame()
+{
+  if (cacheFrame != CurrentInputFrame()) {
+    ResetCache();
+  }
+}
+
 bool Key::Down(KeyCode key)
 {
+  EnsureCurrentFrame();
+
   static auto GetKeyDownInt =
       il2cpp_resolve_icall_typed<bool(KeyCode)>("UnityEngine.Input::GetKeyDownInt(UnityEngine.KeyCode)");
 
@@ -284,6 +306,8 @@ bool Key::Down(KeyCode key)
 
 bool Key::Pressed(KeyCode key)
 {
+  EnsureCurrentFrame();
+
   static auto GetKeyInt =
       il2cpp_resolve_icall_typed<bool(KeyCode)>("UnityEngine.Input::GetKeyInt(UnityEngine.KeyCode)");
 
@@ -296,6 +320,8 @@ bool Key::Pressed(KeyCode key)
 
 bool Key::IsInputFocused()
 {
+  EnsureCurrentFrame();
+
   if (cacheInputFocused == 0) {
     cacheInputFocused = -1;
 

--- a/mods/src/patches/key.h
+++ b/mods/src/patches/key.h
@@ -14,8 +14,9 @@ private:
   static int cacheInputFocused;
   static int cacheInputModified;
 
-  static std::array<int, (int)KeyCode::Max> cacheKeyPressed;
-  static std::array<int, (int)KeyCode::Max> cacheKeyDown;
+  static std::array<int, (int)KeyCode::Max>  cacheKeyPressed;
+  static std::array<int, (int)KeyCode::Max>  cacheKeyDown;
+  static std::array<bool, (int)KeyCode::Max> claimedDirectionalInput;
 
 public:
   static void    ClearInputFocus();
@@ -24,6 +25,9 @@ public:
 
   static bool Pressed(KeyCode key);
   static bool Down(KeyCode key);
+
+  static void ClaimDirectionalInput(KeyCode key);
+  static bool IsDirectionalInputClaimed();
 
   static bool IsModifier(KeyCode key);
 

--- a/mods/src/patches/key.h
+++ b/mods/src/patches/key.h
@@ -13,10 +13,13 @@ private:
 
   static int cacheInputFocused;
   static int cacheInputModified;
+  static int cacheFrame;
 
   static std::array<int, (int)KeyCode::Max>  cacheKeyPressed;
   static std::array<int, (int)KeyCode::Max>  cacheKeyDown;
   static std::array<bool, (int)KeyCode::Max> claimedDirectionalInput;
+
+  static void EnsureCurrentFrame();
 
 public:
   static void    ClearInputFocus();

--- a/mods/src/patches/mapkey.cc
+++ b/mods/src/patches/mapkey.cc
@@ -1,5 +1,6 @@
 #include "mapkey.h"
 #include "gamefunctions.h"
+#include "key.h"
 #include "modifierkey.h"
 #include "str_utils.h"
 #include <prime/KeyCode.h>
@@ -82,6 +83,9 @@ bool MapKey::IsPressed(GameFunction gameFunction)
     if (mapKey.Key != KeyCode::None) {
       if (Key::Pressed(mapKey.Key)) {
         if (MapKey::HasCorrectModifiers(mapKey)) {
+          if (mapKey.hasModifiers) {
+            Key::ClaimDirectionalInput(mapKey.Key);
+          }
           return true;
         }
       }
@@ -98,6 +102,9 @@ bool MapKey::IsDown(GameFunction gameFunction)
     if (mapKey.Key != KeyCode::None) {
       if (Key::Down(mapKey.Key)) {
         if (MapKey::HasCorrectModifiers(mapKey)) {
+          if (mapKey.hasModifiers) {
+            Key::ClaimDirectionalInput(mapKey.Key);
+          }
           return true;
         }
       }

--- a/mods/src/patches/parts/fix_pan.cc
+++ b/mods/src/patches/parts/fix_pan.cc
@@ -8,6 +8,7 @@
 #include <prime/OrbitFrameProvider.h>
 #include <prime/TKTouch.h>
 
+#include <patches/key.h>
 #include <patches/mapkey.h>
 
 #include <spud/detour.h>
@@ -25,7 +26,7 @@ bool NavigationPan_LateUpdate_Hook(auto original, NavigationPan *_this)
 {
   auto d = _this->_lastDelta;
 
-  if (!Config::Get().disable_move_keys) {
+  if (!Config::Get().disable_move_keys && !Key::IsDirectionalInputClaimed()) {
     original(_this);
   }
 


### PR DESCRIPTION
## Summary
- let exact modified MapKey direction chords claim their physical arrow key
- retain claims until key release so one-shot chords cannot leak into native held movement
- make key/input caches self-reset on Unity frame boundaries so independently enabled hook groups remain safe
- make the existing NavigationPan owner yield only to claimed directions while preserving bare-arrow behavior

No new direction assignments or TOML settings are introduced.

Closes #265

## Validation
- Windows release mods build
- Windows releasedbg mods build
- git diff --check
- local releasedbg runtime on integration head d5fed33 (both PR commits cherry-picked onto diagnostics science head 46c7df5)
- deployed/build SHA-256 A7A6CA4344114B85B7C1D41F17515C32D4209DEA6FFBF295DE42DAC0B4D1C744
- after correction: with diagnostics visible, Ctrl+Shift+Up/Down scrolls without native map movement; with diagnostics hidden, directions fall through to native behavior
- clean boot (28 hooks) and zero errors/warnings in 120 post-test log lines