### PR TITLE
Fix text input focus value blocking shortcuts after chat

### DIFF
--- a/mods/src/prime/TMP_InputField.h
+++ b/mods/src/prime/TMP_InputField.h
@@ -44,6 +44,7 @@ public:
   bool __get_isFocused()
   {
     static auto field = get_class_helper().GetProperty("isFocused");
-    return field.Get<bool>(this);
+    const auto* focused = field.Get<bool>(this);
+    return focused && *focused;
   }
 };


### PR DESCRIPTION
A text field that remains selected after losing focus can keep mod shortcuts blocked. `TMP_InputField::isFocused` currently converts the `bool*` returned by `IL2CppPropertyHelper::Get<bool>` directly to `bool`, so a valid pointer to `false` is reported as `true`.

Read the pointed-to value and preserve `nullptr` as `false`. This fixes the focus value used by `Key::IsInputFocused()` and `ClearInputFocus()` without changing hooks or shortcut bindings.

Validation: Windows release build, before/after source-getter regression (focus, release, refocus, unavailable result and recovery), `git diff --check`, and three bounded review lanes passed. The fix also built and booted in the local combined play DLL. The original report—ship selection blocked after leaving chat, recovered by refocusing the game—fits this defect, but its exact live trigger has not been reproduced.
