### PR TITLE
feat: optionally hide artifact Exchange All button

### DIFF
--- a/example_community_patch_settings_da.toml
+++ b/example_community_patch_settings_da.toml
@@ -630,6 +630,8 @@ zoom_reset = "="
 #  <[=================================================================================]> 
 
 [ui]
+# Hide artifact shards "Exchange All"; individual exchanges remain available. Requires restart.
+hide_artifact_exchange_all = false
 # Spring animationen ved åbning af kasser over, og åbn blot kasserne
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -629,6 +629,8 @@ zoom_reset = "="
 #  <[==================================================================================================================================]> 
 
 [ui]
+# Blendet "Alle umtauschen" bei Artefaktfragmenten aus; einzelne Tauschvorgänge bleiben verfügbar. Neustart erforderlich.
+hide_artifact_exchange_all = false
 # Überspringt die Animation und öffnet die Boxen direkt
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/example_community_patch_settings_en-GB-x-cockney.toml
+++ b/example_community_patch_settings_en-GB-x-cockney.toml
@@ -629,6 +629,8 @@ zoom_reset = "="
 #  <[===================================================================]> 
 
 [ui]
+# Hide artifact shards "Exchange All"; individual exchanges remain available. Requires restart.
+hide_artifact_exchange_all = false
 # Skip the reveal box animation, and just open the boxes
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/example_community_patch_settings_en-x-minionese.toml
+++ b/example_community_patch_settings_en-x-minionese.toml
@@ -629,6 +629,8 @@ zoom_reset = "="
 #  <[==================]> 
 
 [ui]
+# Hide artifact shards "Exchange All"; individual exchanges remain available. Requires restart.
+hide_artifact_exchange_all = false
 # Skip the reveal box animation, and just open the boxes
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -629,6 +629,8 @@ zoom_reset = "="
 #  <[===================================================================]> 
 
 [ui]
+# Hide artifact shards "Exchange All"; individual exchanges remain available. Requires restart.
+hide_artifact_exchange_all = false
 # Skip the reveal box animation, and just open the boxes
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/example_community_patch_settings_es.toml
+++ b/example_community_patch_settings_es.toml
@@ -629,6 +629,8 @@ zoom_reset = "="
 #  <[============================================================]> 
 
 [ui]
+# Hide artifact shards "Exchange All"; individual exchanges remain available. Requires restart.
+hide_artifact_exchange_all = false
 # Omite la animación de revelado de cajas y simplemente ábrelas
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -629,6 +629,8 @@ zoom_reset = "="
 #  <[===================================================================]> 
 
 [ui]
+# Masque "Tout échanger" pour les fragments d’artefacts ; les échanges individuels restent disponibles. Redémarrage requis.
+hide_artifact_exchange_all = false
 # Ignorer l'animation d'ouverture des coffres et les ouvrir directement
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -629,6 +629,8 @@ zoom_reset = "="
 #  <[===================================================================]> 
 
 [ui]
+# Verberg "Alles inwisselen" voor artefactfragmenten; afzonderlijk inwisselen blijft beschikbaar. Herstart vereist.
+hide_artifact_exchange_all = false
 # Slaat de onthullig animatie van een kist altijd over en opent gewoon de kist
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/example_community_patch_settings_ru.toml
+++ b/example_community_patch_settings_ru.toml
@@ -629,6 +629,8 @@ zoom_reset = "="
 #  <[===================================================================]> 
 
 [ui]
+# Hide artifact shards "Exchange All"; individual exchanges remain available. Requires restart.
+hide_artifact_exchange_all = false
 # Пропускать анимацию открытия контейнеров и сразу открывать их
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/example_community_patch_settings_tlh.toml
+++ b/example_community_patch_settings_tlh.toml
@@ -629,6 +629,8 @@ zoom_reset = "="
 #  <[========================================================================================]> 
 
 [ui]
+# Hide artifact shards "Exchange All"; individual exchanges remain available. Requires restart.
+hide_artifact_exchange_all = false
 # Skip  reveal box animation, 'ej just poSmoH  boxes
 always_skip_reveal_sequence = true
 auto_confirm_discovery = true

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -1111,6 +1111,8 @@ void Config::Load()
   this->mission_hud_buttons.emplace(
       "missions", get_mission_hud_visibility(config, parsed, "hud_missions", DCU::hud_missions, write_config));
   this->installMissionHudTweaksHooks = this->MissionHudTweaksEnabled();
+  this->hide_artifact_exchange_all = get_config_or_default(
+      config, parsed, "ui", "hide_artifact_exchange_all", DCU::hide_artifact_exchange_all, write_config);
 
   spdlog::debug("");
 

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -260,6 +260,7 @@ public:
   bool installTestPatches;
   bool installMiscPatches;
   bool installMissionHudTweaksHooks;
+  bool hide_artifact_exchange_all;
   bool installChatPatches;
   bool installSyncPatches;
   bool installGameVersionHook;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -226,6 +226,7 @@ namespace Sync
 
 namespace UI
 {
+  constexpr bool hide_artifact_exchange_all = false;
   constexpr bool        always_skip_reveal_sequence = true;
   constexpr bool        arrow_keys_to_select_ship   = true;
   constexpr bool        auto_confirm_discovery      = true;

--- a/mods/src/patches/parts/artifact_exchange.cc
+++ b/mods/src/patches/parts/artifact_exchange.cc
@@ -33,10 +33,14 @@ void InstallArtifactExchangeHooks()
     spdlog::warn("[ArtifactExchange] popup class unavailable; leaving game unchanged");
     return;
   }
-  auto field      = controller.GetField("_convertAllButton");
-  auto bind       = controller.GetMethod("OnDidBindCanvasContext", 0);
-  get_game_object = il2cpp_resolve_icall_typed<void*(void*)>("UnityEngine.Component::get_gameObject()");
-  set_active      = il2cpp_resolve_icall_typed<void(void*, bool)>("UnityEngine.GameObject::SetActive(System.Boolean)");
+  auto field = controller.GetField("_convertAllButton");
+  auto bind  = controller.GetMethod("OnDidBindCanvasContext", 0);
+  // Current Unity exposes injected native entry points; use the managed wrappers
+  // that accept component/GameObject instances, as the other UI patches do.
+  auto component   = il2cpp_get_class_helper("UnityEngine.CoreModule", "UnityEngine", "Component");
+  auto game_object = il2cpp_get_class_helper("UnityEngine.CoreModule", "UnityEngine", "GameObject");
+  get_game_object  = component.GetMethod<void*(void*)>("get_gameObject", 0);
+  set_active       = game_object.GetMethod<void(void*, bool)>("SetActive", 1);
   if (!field.isValidHelper() || field.offset() < sizeof(Il2CppObject) || !bind || !get_game_object || !set_active) {
     spdlog::warn("[ArtifactExchange] required popup API unavailable; leaving game unchanged");
     return;

--- a/mods/src/patches/parts/artifact_exchange.cc
+++ b/mods/src/patches/parts/artifact_exchange.cc
@@ -1,0 +1,47 @@
+#include "config.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <spdlog/spdlog.h>
+#include <spud/detour.h>
+
+namespace
+{
+ptrdiff_t convert_all_offset    = 0;
+void* (*get_game_object)(void*) = nullptr;
+void (*set_active)(void*, bool) = nullptr;
+
+void InventoryUsePopup_Bind_Hook(auto original, void* controller)
+{
+  original(controller);
+  if (!controller)
+    return;
+  auto* button = *reinterpret_cast<void**>(static_cast<char*>(controller) + convert_all_offset);
+  if (button) {
+    if (auto* object = get_game_object(button))
+      set_active(object, false);
+  }
+}
+} // namespace
+
+void InstallArtifactExchangeHooks()
+{
+  // This dedicated field belongs to artifact bulk conversion, not the inventory
+  // entry button or the individual exchange controls. Hide it after normal setup.
+  auto controller =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Inventories", "InventoryUsePopupViewController");
+  if (!controller.isValidHelper()) {
+    spdlog::warn("[ArtifactExchange] popup class unavailable; leaving game unchanged");
+    return;
+  }
+  auto field      = controller.GetField("_convertAllButton");
+  auto bind       = controller.GetMethod("OnDidBindCanvasContext", 0);
+  get_game_object = il2cpp_resolve_icall_typed<void*(void*)>("UnityEngine.Component::get_gameObject()");
+  set_active      = il2cpp_resolve_icall_typed<void(void*, bool)>("UnityEngine.GameObject::SetActive(System.Boolean)");
+  if (!field.isValidHelper() || field.offset() < sizeof(Il2CppObject) || !bind || !get_game_object || !set_active) {
+    spdlog::warn("[ArtifactExchange] required popup API unavailable; leaving game unchanged");
+    return;
+  }
+  convert_all_offset = field.offset();
+  SPUD_STATIC_DETOUR(bind, InventoryUsePopup_Bind_Hook);
+  spdlog::info("[ArtifactExchange] hiding artifact Exchange All button");
+}

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -33,6 +33,7 @@ void InstallDailyFactionBulkClaimHooks();
 void InstallTestPatches();
 void InstallMiscPatches();
 void InstallMissionHudTweaksHooks();
+void InstallArtifactExchangeHooks();
 void InstallChatPatches();
 void InstallTempCrashFixes();
 void InstallSyncPatches();
@@ -137,6 +138,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"TestPatches", {InstallTestPatches, &cfg.installTestPatches}},
       {"MiscPatches", {InstallMiscPatches, &cfg.installMiscPatches}},
       {"MissionHudTweaksHooks", {InstallMissionHudTweaksHooks, &cfg.installMissionHudTweaksHooks}},
+      {"ArtifactExchangeHooks", {InstallArtifactExchangeHooks, &cfg.hide_artifact_exchange_all}},
       {"ChatPatches", {InstallChatPatches, &cfg.installChatPatches}},
       {"SyncPatches", {InstallSyncPatches, &cfg.installSyncPatches}},
       {"ObjectTracker", {InstallObjectTrackers, &cfg.installObjectTracker}},


### PR DESCRIPTION
Adds an opt-in setting to hide the artifact shard exchange popup's **Exchange All / Convert All** button, reducing accidental bulk exchanges.

```toml
[ui]
hide_artifact_exchange_all = true
```

Defaults to `false`; changing it requires a restart. The popup hook hides its dedicated bulk-convert button after normal binding, preserving individual exchanges and inventory navigation.

Missing runtime metadata leaves the game unchanged and logs a warning.
