### PR TITLE
Add reusable native settings framework with Fleet Commander confirmation first

### DIFF
--- a/docs/MOD_SETTINGS_FOUNDATION.md
+++ b/docs/MOD_SETTINGS_FOUNDATION.md
@@ -1,0 +1,64 @@
+# Boolean settings foundation (P1)
+
+This is the controller and Fleet Commander preference adapter for a forthcoming
+native settings UI. It does not yet insert rows or persist mod-owned TOML settings.
+
+`settings/boolean_settings.h` is independent of Unity and storage. Definitions have
+a stable ID, readable label, read callback, and immediate-write callback. Registry
+IDs are unique and registration freezes on first lookup. All operations belong to
+the constructing thread; there is no polling, background work or disk I/O.
+
+Consumers must keep unknown state separate from a boolean. `ReadResult` carries
+availability, an optional positive value, and an adapter generation. A snapshot
+also carries controller identity, revision and lifecycle epoch. Passing a stale
+or foreign snapshot rejects the request. `RenderScope` suppresses user-write
+handling around native binding/refresh callbacks. Reentrant application is Busy.
+
+Writes re-read before applying, skip already-satisfied values and verify readback.
+Failed or uncertain writes never trigger an automatic reverse write. The returned
+snapshot contains a fresh authoritative read when available; `Unverified` must
+not be rendered as successful application. `AppliedVerified` is local verification,
+not a claim of cloud durability.
+
+## Fleet Commander adapter
+
+`FleetCommanderConfirmationSetting()` provides one shared setting for the recovery
+shortcut and future UI. ON means show confirmation. Reads use the existing
+PersistentPrefsManager's `GetBool(key, false, false)`: the final false prevents
+insertion of a missing preference while preserving the game's default. Writes use
+the native FC setter. The adapter never instantiates managers, invokes abilities,
+forces cloud saves, or enumerates other preferences.
+
+Metadata is resolved lazily and checked before access. Two weak handles detect
+replacement of the preference manager or saved-data object without retaining
+account data. Unavailability invalidates the observed generation. One process-wide
+root holds the constant, non-sensitive preference key; no work runs while idle.
+
+P2 **must** wire `InvalidateFleetCommanderConfirmationSession()` to reliable
+account/reload lifecycle notifications before retaining UI snapshots. Observed
+object identity alone cannot prove that an account transition did not happen
+between two reads. The current shortcut takes and consumes a fresh snapshot in
+one game-thread operation; this change introduces no long-lived native UI snapshot.
+Context teardown, widget ownership, native error presentation and per-platform UI
+hook evidence are P2 work, not claims of this foundation.
+
+The existing Ctrl+Alt+F8 shortcut remains one-way and keeps its input/config guards.
+Its log distinguishes already-enabled, verified application and unverified failure.
+
+## Standalone controller tests
+
+Windows (clang++ with the installed C++ toolchain):
+
+```powershell
+clang++ -std=c++23 -Wall -Wextra -Werror -I mods/src tests/boolean_settings_test.cc -o boolean_settings_test.exe
+./boolean_settings_test.exe
+```
+
+On Unix, use the equivalent compiler invocation with `-pthread`. Keep executables
+outside tracked source. These tests cover the pure state machine, not native ABI,
+account lifecycle wiring, frame timings, or cloud persistence.
+
+Before extending the UI, measure the baseline and candidate with the same scene,
+FPS cap and diagnostics: no scheduled closed-menu work or per-frame allocations;
+initial target <=1 ms added normal bind/refresh work at p95, <=2 ms per normal
+operation. These are proposed UI acceptance budgets, not measured P1 results.

--- a/docs/MOD_SETTINGS_FOUNDATION.md
+++ b/docs/MOD_SETTINGS_FOUNDATION.md
@@ -1,7 +1,8 @@
-# Boolean settings foundation (P1)
+# Boolean settings foundation and native FC control
 
-This is the controller and Fleet Commander preference adapter for a forthcoming
-native settings UI. It does not yet insert rows or persist mod-owned TOML settings.
+The controller and Fleet Commander preference adapter are shared by the recovery
+shortcut and a Windows x64 native confirmation-page adapter. Mod-owned TOML
+persistence and the Community Mod category are separate work.
 
 `settings/boolean_settings.h` is independent of Unity and storage. Definitions have
 a stable ID, readable label, read callback, and immediate-write callback. Registry
@@ -34,13 +35,12 @@ replacement of the preference manager or saved-data object without retaining
 account data. Unavailability invalidates the observed generation. One process-wide
 root holds the constant, non-sensitive preference key; no work runs while idle.
 
-P2 **must** wire `InvalidateFleetCommanderConfirmationSession()` to reliable
-account/reload lifecycle notifications before retaining UI snapshots. Observed
-object identity alone cannot prove that an account transition did not happen
-between two reads. The current shortcut takes and consumes a fresh snapshot in
-one game-thread operation; this change introduces no long-lived native UI snapshot.
-Context teardown, widget ownership, native error presentation and per-platform UI
-hook evidence are P2 work, not claims of this foundation.
+The UI calls `InvalidateFleetCommanderConfirmationSession()` before the native
+preference manager's RegisterEvents (initialization/reload), session-start handler,
+and cloud-load entry. It immediately invalidates live view snapshots. These are
+substantive functions; neither the tiny OnApplicationReload wrapper nor the
+LifecycleUpdatedEventHandler save-timer path is hooked. Exact-client account
+transition validation is still required; object identity alone is insufficient.
 
 The existing Ctrl+Alt+F8 shortcut remains one-way and keeps its input/config guards.
 Its log distinguishes already-enabled, verified application and unverified failure.
@@ -62,3 +62,52 @@ Before extending the UI, measure the baseline and candidate with the same scene,
 FPS cap and diagnostics: no scheduled closed-menu work or per-frame allocations;
 initial target <=1 ms added normal bind/refresh work at p95, <=2 ms per normal
 operation. These are proposed UI acceptance budgets, not measured P1 results.
+
+## Native UI adapter (P2 candidate)
+
+The first registered control is `[MOD] Confirm Fleet Commander abilities`, under
+the existing confirmation category. ON means show confirmations; OFF means skip.
+The adapter is independent of mod hotkeys and does not install a global localization
+hook. It overrides TextLocalizer after native binding and clears its own overrides
+on release/rebind, using weak ownership records rather than matching visible text.
+
+`BooleanView` retains the displayed snapshot. Rendering suppresses writes; stale
+clicks conflict; an uncertain apply remains unresolved until a subsequent bind.
+Rejected writes with known readback retain that value and show a retry message.
+Unknown values suppress both native switch/state visual nodes while retaining the
+label. The prefab must prove that those nodes are descendants of the row and do
+not contain the label; otherwise that UI is unsupported. Exact visual validation
+of this behavior remains a release gate.
+
+Eight weak view records bound bookkeeping. Native contexts own rows/delegates;
+there are no strong roots retaining historical settings pages. Native release
+clears records, with dead-record reclamation on binding as a fallback. A successful
+write refreshes other live framework views. No polling or file work is scheduled.
+
+Each callback registration owns a permanent MethodInfo copy with replaced direct,
+virtual and runtime-invoker pointers. Matching native schema supplies reflection
+metadata only; the donor MethodInfo remains untouched. Closed delegates must point
+to that owned descriptor. The native setter delegate is deliberately inert:
+only a live widget's explicit change handler can submit its displayed snapshot.
+Reflection and refresh callbacks cannot authorize writes. This does not claim a
+general managed-method registration API.
+
+All seven hook bodies are preflighted for signatures, distinct addresses, exact
+Windows unwind-table entries and at least 64 bytes of native extent. Hooks remain
+inert until installation completes. Other platforms retain the independent FC
+shortcut; UI support awaits their own native extent and runtime evidence.
+
+Additional standalone tests:
+
+```powershell
+clang++ -std=c++23 -Wall -Wextra -Werror -I mods/src tests/boolean_view_test.cc -o boolean_view_test.exe
+./boolean_view_test.exe
+clang++ -std=c++23 -Wall -Wextra -Werror -Wno-unused-parameter -I mods/src -I third_party/libil2cpp tests/native_boolean_callback_test.cc -o native_boolean_callback_test.exe
+./native_boolean_callback_test.exe
+```
+
+These cover view failure transitions and owned native callback invocation pointers.
+They do not establish delegate construction, DynamicInvoke, Unity pooling, unknown
+prefab presentation, account transitions, cloud durability or frame-time budgets
+on a running game. Those require the exact candidate artifact, not the earlier
+play prototype's successful tests.

--- a/docs/MOD_SETTINGS_FOUNDATION.md
+++ b/docs/MOD_SETTINGS_FOUNDATION.md
@@ -1,7 +1,7 @@
 # Boolean settings foundation and native FC control
 
-The controller and Fleet Commander preference adapter are shared by the recovery
-shortcut and a Windows x64 native confirmation-page adapter. Mod-owned TOML
+The controller and Fleet Commander preference adapter back a Windows x64 native
+confirmation-page control. Mod-owned TOML
 persistence and the Community Mod category are separate work.
 
 `settings/boolean_settings.h` is independent of Unity and storage. Definitions have
@@ -23,8 +23,7 @@ not a claim of cloud durability.
 
 ## Fleet Commander adapter
 
-`FleetCommanderConfirmationSetting()` provides one shared setting for the recovery
-shortcut and future UI. ON means show confirmation. Reads use the existing
+`FleetCommanderConfirmationSetting()` provides the native UI setting. ON means show confirmation. Reads use the existing
 PersistentPrefsManager's `GetBool(key, false, false)`: the final false prevents
 insertion of a missing preference while preserving the game's default. Writes use
 the native FC setter. The adapter never instantiates managers, invokes abilities,
@@ -42,8 +41,8 @@ substantive functions; neither the tiny OnApplicationReload wrapper nor the
 LifecycleUpdatedEventHandler save-timer path is hooked. Exact-client account
 transition validation is still required; object identity alone is insufficient.
 
-The existing Ctrl+Alt+F8 shortcut remains one-way and keeps its input/config guards.
-Its log distinguishes already-enabled, verified application and unverified failure.
+The prototype recovery shortcut has been removed. Use the native settings row;
+legacy `enable_fc_ability_confirmation` entries are no longer consumed.
 
 ## Standalone controller tests
 
@@ -94,8 +93,8 @@ general managed-method registration API.
 
 All seven hook bodies are preflighted for signatures, distinct addresses, exact
 Windows unwind-table entries and at least 64 bytes of native extent. Hooks remain
-inert until installation completes. Other platforms retain the independent FC
-shortcut; UI support awaits their own native extent and runtime evidence.
+inert until installation completes. Other platforms omit this control; support
+awaits their own native extent and runtime evidence.
 
 Additional standalone tests:
 

--- a/example_community_patch_settings_da.toml
+++ b/example_community_patch_settings_da.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Genaktivér bekræftelser for flådekommandørers aktive evner (aktiverer ikke en evne).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Om lokalisering skal tillades, når forhåndsvisninger vises
 toggle_preview_locate = "CTRL-R"

--- a/example_community_patch_settings_da.toml
+++ b/example_community_patch_settings_da.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # Skift automatisk bekræftelse af øjeblikkelig warp mellem ingen, warp og hop
 toggle_instant_warp = "ALT-I"
 
-# Genaktivér bekræftelser for flådekommandørers aktive evner (aktiverer ikke en evne).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Om lokalisering skal tillades, når forhåndsvisninger vises
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_da.toml
+++ b/example_community_patch_settings_da.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # Skift automatisk bekræftelse af øjeblikkelig warp mellem ingen, warp og hop
 toggle_instant_warp = "ALT-I"
 
+# Genaktivér bekræftelser for flådekommandørers aktive evner (aktiverer ikke en evne).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Om lokalisering skal tillades, når forhåndsvisninger vises
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # Wechselt die automatische Sofort-Warp-Bestätigung zwischen none, warp und jump
 toggle_instant_warp = "ALT-I"
 
-# Bestätigungen für aktive Flottenkommandanten-Fähigkeiten wieder einschalten (aktiviert keine Fähigkeit).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Legt fest, ob Orten bei angezeigten Vorschauen erlaubt ist
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # Wechselt die automatische Sofort-Warp-Bestätigung zwischen none, warp und jump
 toggle_instant_warp = "ALT-I"
 
+# Bestätigungen für aktive Flottenkommandanten-Fähigkeiten wieder einschalten (aktiviert keine Fähigkeit).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Legt fest, ob Orten bei angezeigten Vorschauen erlaubt ist
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Bestätigungen für aktive Flottenkommandanten-Fähigkeiten wieder einschalten (aktiviert keine Fähigkeit).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Legt fest, ob Orten bei angezeigten Vorschauen erlaubt ist
 toggle_preview_locate = "CTRL-R"

--- a/example_community_patch_settings_en-GB-x-cockney.toml
+++ b/example_community_patch_settings_en-GB-x-cockney.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # Cycle the instant-warp choice: none, warp, or jump
 toggle_instant_warp = "ALT-I"
 
-# Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Whether to allow locate when previews are displayed
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_en-GB-x-cockney.toml
+++ b/example_community_patch_settings_en-GB-x-cockney.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Whether to allow locate when previews are displayed
 toggle_preview_locate = "CTRL-R"

--- a/example_community_patch_settings_en-GB-x-cockney.toml
+++ b/example_community_patch_settings_en-GB-x-cockney.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # Cycle the instant-warp choice: none, warp, or jump
 toggle_instant_warp = "ALT-I"
 
+# Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Whether to allow locate when previews are displayed
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_en-x-minionese.toml
+++ b/example_community_patch_settings_en-x-minionese.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # Whether to automatically warp, jump or display the dialog
 toggle_instant_warp = "ALT-I"
 
-# Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Whether to allow locate when previews are displayed
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_en-x-minionese.toml
+++ b/example_community_patch_settings_en-x-minionese.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # Whether to automatically warp, jump or display the dialog
 toggle_instant_warp = "ALT-I"
 
+# Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Whether to allow locate when previews are displayed
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_en-x-minionese.toml
+++ b/example_community_patch_settings_en-x-minionese.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Whether to allow locate when previews are displayed
 toggle_preview_locate = "CTRL-R"

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Whether to allow locate when previews are displayed
 toggle_preview_locate = "CTRL-R"

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # Cycle instant-warp auto-confirm between none, warp, and jump
 toggle_instant_warp = "ALT-I"
 
-# Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Whether to allow locate when previews are displayed
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # Cycle instant-warp auto-confirm between none, warp, and jump
 toggle_instant_warp = "ALT-I"
 
+# Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Whether to allow locate when previews are displayed
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_es.toml
+++ b/example_community_patch_settings_es.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # Alterna la confirmación automática de curvatura instantánea entre ninguna, curvatura y salto
 toggle_instant_warp = "ALT-I"
 
+# Restablecer las confirmaciones de habilidades activas de comandantes de flota (no activa ninguna habilidad).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Indica si se permite localizar cuando se muestran vistas previas
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_es.toml
+++ b/example_community_patch_settings_es.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # Alterna la confirmación automática de curvatura instantánea entre ninguna, curvatura y salto
 toggle_instant_warp = "ALT-I"
 
-# Restablecer las confirmaciones de habilidades activas de comandantes de flota (no activa ninguna habilidad).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Indica si se permite localizar cuando se muestran vistas previas
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_es.toml
+++ b/example_community_patch_settings_es.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Restablecer las confirmaciones de habilidades activas de comandantes de flota (no activa ninguna habilidad).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Indica si se permite localizar cuando se muestran vistas previas
 toggle_preview_locate = "CTRL-R"

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # Faire défiler la confirmation automatique entre none, warp et jump
 toggle_instant_warp = "ALT-I"
 
-# Réactiver les confirmations des capacités actives des commandants de flotte (sans activer de capacité).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Autoriser la localisation lorsque les aperçus sont affichés
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Réactiver les confirmations des capacités actives des commandants de flotte (sans activer de capacité).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Autoriser la localisation lorsque les aperçus sont affichés
 toggle_preview_locate = "CTRL-R"

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # Faire défiler la confirmation automatique entre none, warp et jump
 toggle_instant_warp = "ALT-I"
 
+# Réactiver les confirmations des capacités actives des commandants de flotte (sans activer de capacité).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Autoriser la localisation lorsque les aperçus sont affichés
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Bevestigingen voor actieve vlootcommandantvaardigheden herstellen (activeert geen vaardigheid).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Bepaald of je lokaliseren wilt toelaten als je vracht bekijkt
 toggle_preview_locate = "CTRL-R"

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # Wissel de automatische bevestiging tussen none, warp en jump
 toggle_instant_warp = "ALT-I"
 
-# Bevestigingen voor actieve vlootcommandantvaardigheden herstellen (activeert geen vaardigheid).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Bepaald of je lokaliseren wilt toelaten als je vracht bekijkt
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # Wissel de automatische bevestiging tussen none, warp en jump
 toggle_instant_warp = "ALT-I"
 
+# Bevestigingen voor actieve vlootcommandantvaardigheden herstellen (activeert geen vaardigheid).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Bepaald of je lokaliseren wilt toelaten als je vracht bekijkt
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_ru.toml
+++ b/example_community_patch_settings_ru.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Включить подтверждения активных способностей командиров флота (не активирует способность).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Разрешать ли поиск при отображении предпросмотра
 toggle_preview_locate = "CTRL-R"

--- a/example_community_patch_settings_ru.toml
+++ b/example_community_patch_settings_ru.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # Переключает автоподтверждение мгновенного варпа: нет, варп или прыжок
 toggle_instant_warp = "ALT-I"
 
-# Включить подтверждения активных способностей командиров флота (не активирует способность).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Разрешать ли поиск при отображении предпросмотра
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_ru.toml
+++ b/example_community_patch_settings_ru.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # Переключает автоподтверждение мгновенного варпа: нет, варп или прыжок
 toggle_instant_warp = "ALT-I"
 
+# Включить подтверждения активных способностей командиров флота (не активирует способность).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Разрешать ли поиск при отображении предпросмотра
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_tlh.toml
+++ b/example_community_patch_settings_tlh.toml
@@ -307,6 +307,10 @@ toggle_cargo_station = "ALT-3"
 # none, warp, jump je joj SIbI' leng chaw' choH
 toggle_instant_warp = "ALT-I"
 
+# Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
+# NONE = unassigned. Result is logged; the game handles cloud persistence.
+enable_fc_ability_confirmation = "NONE"
+
 # Whether Daq  chaw' locate ghorgh previews are displayed
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_tlh.toml
+++ b/example_community_patch_settings_tlh.toml
@@ -307,10 +307,6 @@ toggle_cargo_station = "ALT-3"
 # none, warp, jump je joj SIbI' leng chaw' choH
 toggle_instant_warp = "ALT-I"
 
-# Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
-# NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "CTRL-ALT-F8"
-
 # Whether Daq  chaw' locate ghorgh previews are displayed
 toggle_preview_locate = "CTRL-R"
 

--- a/example_community_patch_settings_tlh.toml
+++ b/example_community_patch_settings_tlh.toml
@@ -309,7 +309,7 @@ toggle_instant_warp = "ALT-I"
 
 # Re-enable Fleet Commander active ability confirmations (one-way reset; never activates an ability).
 # NONE = unassigned. Result is logged; the game handles cloud persistence.
-enable_fc_ability_confirmation = "NONE"
+enable_fc_ability_confirmation = "CTRL-ALT-F8"
 
 # Whether Daq  chaw' locate ghorgh previews are displayed
 toggle_preview_locate = "CTRL-R"

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -1047,6 +1047,8 @@ void Config::Load()
   this->auto_confirm_instant_warp =
       get_auto_confirm_instant_warp(config, parsed, DCU::auto_confirm_instant_warp, write_config);
   this->installInstantWarpConfirmationHooks = true;
+  // Internal installation switch; UI availability is checked by the native adapter.
+  this->installModConfirmationSettings = true;
   read_instant_warp_filter(config, parsed, "instant_warp_auto_jump", this->instant_warp_auto_jump,
                            this->instant_warp_auto_jump_all, DCU::instant_warp_auto_jump, write_config);
   read_instant_warp_filter(config, parsed, "instant_warp_auto_warp", this->instant_warp_auto_warp,

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -1373,6 +1373,8 @@ void Config::Load()
   parse_config_shortcut(config, parsed, "toggle_queue", GameFunction::ToggleQueue, DCSH::toggle_queue);
   parse_config_shortcut(config, parsed, "toggle_instant_warp", GameFunction::ToggleAutoConfirmInstantWarp,
                         DCSH::toggle_instant_warp);
+  parse_config_shortcut(config, parsed, "enable_fc_ability_confirmation", GameFunction::EnableFcAbilityConfirmation,
+                        DCSH::enable_fc_ability_confirmation);
 
   if (this->hotkeys_extended) {
     parse_config_shortcut(config, parsed, "show_alliance", GameFunction::ShowAlliance, DCSH::show_alliance);

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -1375,8 +1375,6 @@ void Config::Load()
   parse_config_shortcut(config, parsed, "toggle_queue", GameFunction::ToggleQueue, DCSH::toggle_queue);
   parse_config_shortcut(config, parsed, "toggle_instant_warp", GameFunction::ToggleAutoConfirmInstantWarp,
                         DCSH::toggle_instant_warp);
-  parse_config_shortcut(config, parsed, "enable_fc_ability_confirmation", GameFunction::EnableFcAbilityConfirmation,
-                        DCSH::enable_fc_ability_confirmation);
 
   if (this->hotkeys_extended) {
     parse_config_shortcut(config, parsed, "show_alliance", GameFunction::ShowAlliance, DCSH::show_alliance);

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -268,6 +268,7 @@ public:
   bool installDailyFactionBulkClaimHooks;
   bool installInstantWarpConfirmationHooks;
   bool installAudioEventHooks;
+  bool installModConfirmationSettings;
 
   std::string config_settings_url;
   std::string config_assets_url_override;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -176,7 +176,7 @@ namespace Shortcuts
   constexpr const char* toggle_cargo_player   = "ALT-2";
   constexpr const char* toggle_cargo_station  = "ALT-3";
   constexpr const char* toggle_instant_warp   = "ALT-I";
-  constexpr const char* enable_fc_ability_confirmation = "NONE";
+  constexpr const char* enable_fc_ability_confirmation = "CTRL-ALT-F8";
   constexpr const char* toggle_preview_locate = "CTRL-R";
   constexpr const char* toggle_preview_recall = "CTRL-T";
   constexpr const char* ui_scaledown          = "PGDOWN";

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -176,6 +176,7 @@ namespace Shortcuts
   constexpr const char* toggle_cargo_player   = "ALT-2";
   constexpr const char* toggle_cargo_station  = "ALT-3";
   constexpr const char* toggle_instant_warp   = "ALT-I";
+  constexpr const char* enable_fc_ability_confirmation = "NONE";
   constexpr const char* toggle_preview_locate = "CTRL-R";
   constexpr const char* toggle_preview_recall = "CTRL-T";
   constexpr const char* ui_scaledown          = "PGDOWN";

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -176,7 +176,6 @@ namespace Shortcuts
   constexpr const char* toggle_cargo_player   = "ALT-2";
   constexpr const char* toggle_cargo_station  = "ALT-3";
   constexpr const char* toggle_instant_warp   = "ALT-I";
-  constexpr const char* enable_fc_ability_confirmation = "CTRL-ALT-F8";
   constexpr const char* toggle_preview_locate = "CTRL-R";
   constexpr const char* toggle_preview_recall = "CTRL-T";
   constexpr const char* ui_scaledown          = "PGDOWN";

--- a/mods/src/patches/gamefunctions.h
+++ b/mods/src/patches/gamefunctions.h
@@ -103,7 +103,6 @@ enum GameFunction {
   ShowShipConstruction,
   ShowShields,
   ShowBattlelogs,
-  EnableFcAbilityConfirmation,
 
   // Automatic max value
   Max

--- a/mods/src/patches/gamefunctions.h
+++ b/mods/src/patches/gamefunctions.h
@@ -103,6 +103,7 @@ enum GameFunction {
   ShowShipConstruction,
   ShowShields,
   ShowBattlelogs,
+  EnableFcAbilityConfirmation,
 
   // Automatic max value
   Max

--- a/mods/src/patches/parts/fc_confirmation_reset.cc
+++ b/mods/src/patches/parts/fc_confirmation_reset.cc
@@ -1,0 +1,104 @@
+#include "fc_confirmation_reset.h"
+
+#include <il2cpp-tabledefs.h>
+#include <il2cpp/il2cpp_helper.h>
+#include <spdlog/spdlog.h>
+
+namespace
+{
+
+// Read the existing singleton rather than calling Instance, which can instantiate one during login/reload.
+Il2CppObject* ExistingSingleton(IL2CppClassHelper& helper)
+{
+  auto  parent = helper.GetParent("MonoSingleton`1");
+  auto* cls    = parent.get_cls();
+  auto* field  = cls ? il2cpp_class_get_field_from_name(cls, "s_instance") : nullptr;
+  if (!field || !(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+    return nullptr;
+
+  auto* initialized_field = il2cpp_class_get_field_from_name(cls, "s_initialized");
+  if (!initialized_field || initialized_field->type->type != IL2CPP_TYPE_BOOLEAN
+      || !(initialized_field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+    return nullptr;
+  bool initialized = false;
+  il2cpp_field_static_get_value(initialized_field, &initialized);
+  if (!initialized)
+    return nullptr;
+
+  Il2CppObject* instance = nullptr;
+  il2cpp_field_static_get_value(field, &instance);
+  return instance;
+}
+
+bool ReadBoolField(Il2CppObject* object, const char* name, bool& value)
+{
+  auto* field = il2cpp_class_get_field_from_name(object->klass, name);
+  if (!field || field->type->type != IL2CPP_TYPE_BOOLEAN || (field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+    return false;
+  il2cpp_field_get_value(object, field, &value);
+  return true;
+}
+
+bool ReadHidden(const MethodInfo* getter, Il2CppObject* manager, bool& hidden)
+{
+  Il2CppException* exception = nullptr;
+  auto*            result    = il2cpp_runtime_invoke(getter, manager, nullptr, &exception);
+  if (exception || !result)
+    return false;
+  hidden = *static_cast<bool*>(il2cpp_object_unbox(result));
+  return true;
+}
+
+} // namespace
+
+void EnableFleetCommanderAbilityConfirmation()
+{
+  auto prefs_class =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.PersistentPrefs", "PersistentPrefsManager");
+  auto  fc_class = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.FleetCommander", "FleetCommanderManager");
+  auto* prefs    = ExistingSingleton(prefs_class);
+  auto* manager  = ExistingSingleton(fc_class);
+  bool  loaded   = false;
+  bool  loading  = true;
+  if (!prefs || !manager || !ReadBoolField(prefs, "_isCloudFileLoaded", loaded)
+      || !ReadBoolField(prefs, "_isLoading", loading) || !loaded || loading) {
+    spdlog::warn("[FCConfirmation] Reset unavailable: account preferences are not ready; try again after loading");
+    return;
+  }
+
+  const auto* getter = fc_class.GetMethodInfo("get_HideFleetCommanderAbilityUseConfirmationHidden", 0);
+  const auto* setter = fc_class.GetMethodInfo("set_HideFleetCommanderAbilityUseConfirmationHidden", 1);
+  if (!getter || !setter || getter->return_type->type != IL2CPP_TYPE_BOOLEAN || getter->return_type->byref
+      || setter->return_type->type != IL2CPP_TYPE_VOID || setter->parameters[0]->type != IL2CPP_TYPE_BOOLEAN
+      || setter->parameters[0]->byref || (getter->flags & METHOD_ATTRIBUTE_STATIC)
+      || (setter->flags & METHOD_ATTRIBUTE_STATIC)) {
+    spdlog::error("[FCConfirmation] Reset unavailable: client confirmation methods are missing or incompatible");
+    return;
+  }
+
+  bool hidden = false;
+  if (!ReadHidden(getter, manager, hidden)) {
+    spdlog::error("[FCConfirmation] Could not read confirmation preference; no reset attempted");
+    return;
+  }
+  spdlog::info("[FCConfirmation] Before reset: hide_fcaa_use_confirmation={}", hidden);
+  if (!hidden) {
+    spdlog::info("[FCConfirmation] Fleet Commander ability confirmation is already enabled");
+    return;
+  }
+
+  // Use the same client setter as the preference UI. Never activate an ability or force a cloud upload.
+  bool             hide_confirmation = false;
+  void*            args[]            = {&hide_confirmation};
+  Il2CppException* exception         = nullptr;
+  il2cpp_runtime_invoke(setter, manager, args, &exception);
+  if (exception) {
+    spdlog::error("[FCConfirmation] Client setter failed; confirmation state is unverified");
+    return;
+  }
+  if (!ReadHidden(getter, manager, hidden) || hidden) {
+    spdlog::error("[FCConfirmation] Reset readback failed; confirmation state is unverified");
+    return;
+  }
+  spdlog::info("[FCConfirmation] Fleet Commander ability confirmation enabled (hide=false); cloud persistence pending");
+}

--- a/mods/src/patches/parts/fc_confirmation_reset.cc
+++ b/mods/src/patches/parts/fc_confirmation_reset.cc
@@ -2,7 +2,6 @@
 #include "settings/boolean_settings.h"
 #include <il2cpp-tabledefs.h>
 #include <il2cpp/il2cpp_helper.h>
-#include <spdlog/spdlog.h>
 
 namespace
 {
@@ -160,26 +159,7 @@ mod_settings::BooleanSetting& FleetCommanderConfirmationSetting()
 
 void InvalidateFleetCommanderConfirmationSession()
 {
-  // P2 must connect this to account/context lifecycle before retaining UI snapshots.
+  // The native UI calls this before preference-session boundaries.
   FleetCommanderConfirmationSetting().InvalidateSession();
   Backend().invalidate();
-}
-
-void EnableFleetCommanderAbilityConfirmation()
-{
-  auto&      setting = FleetCommanderConfirmationSetting();
-  const auto result  = setting.SetFromUser(true, setting.Observe());
-  using mod_settings::Outcome;
-  switch (result.outcome) {
-    case Outcome::AppliedVerified:
-      spdlog::info("[FCConfirmation] Fleet Commander ability confirmation enabled; cloud persistence game-managed");
-      break;
-    case Outcome::Unchanged:
-      spdlog::info("[FCConfirmation] Fleet Commander ability confirmation is already enabled");
-      break;
-    default:
-      spdlog::warn("[FCConfirmation] Confirmation recovery not verified (status={}); retry after loading",
-                   static_cast<int>(result.outcome));
-      break;
-  }
 }

--- a/mods/src/patches/parts/fc_confirmation_reset.cc
+++ b/mods/src/patches/parts/fc_confirmation_reset.cc
@@ -1,104 +1,185 @@
 #include "fc_confirmation_reset.h"
-
+#include "settings/boolean_settings.h"
 #include <il2cpp-tabledefs.h>
 #include <il2cpp/il2cpp_helper.h>
 #include <spdlog/spdlog.h>
 
 namespace
 {
+using namespace mod_settings;
+constexpr const char* PreferenceKey = "options/hide_fcaa_use_confirmation";
 
-// Read the existing singleton rather than calling Instance, which can instantiate one during login/reload.
+bool ReferenceField(const FieldInfo* field)
+{
+  if (!field || field->type->byref)
+    return false;
+  const auto type = field->type->type;
+  return type == IL2CPP_TYPE_CLASS || type == IL2CPP_TYPE_GENERICINST || type == IL2CPP_TYPE_OBJECT;
+}
 Il2CppObject* ExistingSingleton(IL2CppClassHelper& helper)
 {
-  auto  parent = helper.GetParent("MonoSingleton`1");
-  auto* cls    = parent.get_cls();
-  auto* field  = cls ? il2cpp_class_get_field_from_name(cls, "s_instance") : nullptr;
-  if (!field || !(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
-    return nullptr;
-
-  auto* initialized_field = il2cpp_class_get_field_from_name(cls, "s_initialized");
-  if (!initialized_field || initialized_field->type->type != IL2CPP_TYPE_BOOLEAN
-      || !(initialized_field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+  auto  parent           = helper.GetParent("MonoSingleton`1");
+  auto* cls              = parent.get_cls();
+  auto* instanceField    = cls ? il2cpp_class_get_field_from_name(cls, "s_instance") : nullptr;
+  auto* initializedField = cls ? il2cpp_class_get_field_from_name(cls, "s_initialized") : nullptr;
+  if (!ReferenceField(instanceField) || !(instanceField->type->attrs & FIELD_ATTRIBUTE_STATIC) || !initializedField
+      || initializedField->type->type != IL2CPP_TYPE_BOOLEAN
+      || !(initializedField->type->attrs & FIELD_ATTRIBUTE_STATIC))
     return nullptr;
   bool initialized = false;
-  il2cpp_field_static_get_value(initialized_field, &initialized);
+  il2cpp_field_static_get_value(initializedField, &initialized);
   if (!initialized)
     return nullptr;
-
   Il2CppObject* instance = nullptr;
-  il2cpp_field_static_get_value(field, &instance);
-  return instance;
+  il2cpp_field_static_get_value(instanceField, &instance);
+  return instance && il2cpp_class_is_assignable_from(helper.get_cls(), instance->klass) ? instance : nullptr;
+}
+bool BoolField(const FieldInfo* field)
+{
+  return field && field->type->type == IL2CPP_TYPE_BOOLEAN && !field->type->byref
+         && !(field->type->attrs & FIELD_ATTRIBUTE_STATIC);
+}
+bool InstanceMethod(const MethodInfo* method, int count, int result)
+{
+  return method && method->parameters_count == count && method->return_type->type == result
+         && !method->return_type->byref && !(method->flags & METHOD_ATTRIBUTE_STATIC);
 }
 
-bool ReadBoolField(Il2CppObject* object, const char* name, bool& value)
+struct Binding {
+  IL2CppClassHelper prefs =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.PersistentPrefs", "PersistentPrefsManager");
+  IL2CppClassHelper fc =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.FleetCommander", "FleetCommanderManager");
+  const MethodInfo* get = prefs.GetMethodInfo("GetBool", 3);
+  const MethodInfo* set = fc.GetMethodInfo("set_HideFleetCommanderAbilityUseConfirmationHidden", 1);
+  FieldInfo*        loaded =
+      prefs.get_cls() ? il2cpp_class_get_field_from_name(prefs.get_cls(), "_isCloudFileLoaded") : nullptr;
+  FieldInfo* loading = prefs.get_cls() ? il2cpp_class_get_field_from_name(prefs.get_cls(), "_isLoading") : nullptr;
+  FieldInfo* saved   = prefs.get_cls() ? il2cpp_class_get_field_from_name(prefs.get_cls(), "_savedData") : nullptr;
+  // Two bounded weak roots track storage replacement without retaining account data.
+  // Cleared on invalidation while IL2CPP is live, not in a process-exit destructor.
+  Il2CppGCHandle owner = nullptr, data = nullptr, key = nullptr;
+  std::uint64_t  generation = 1;
+  bool           supported() const
+  {
+    return BoolField(loaded) && BoolField(loading) && ReferenceField(saved)
+           && !(saved->type->attrs & FIELD_ATTRIBUTE_STATIC) && InstanceMethod(get, 3, IL2CPP_TYPE_BOOLEAN)
+           && get->parameters[0]->type == IL2CPP_TYPE_STRING && !get->parameters[0]->byref
+           && get->parameters[1]->type == IL2CPP_TYPE_BOOLEAN && !get->parameters[1]->byref
+           && get->parameters[2]->type == IL2CPP_TYPE_BOOLEAN && !get->parameters[2]->byref
+           && InstanceMethod(set, 1, IL2CPP_TYPE_VOID) && set->parameters[0]->type == IL2CPP_TYPE_BOOLEAN
+           && !set->parameters[0]->byref;
+  }
+  void invalidate()
+  {
+    if (owner)
+      il2cpp_gchandle_free(owner);
+    if (data)
+      il2cpp_gchandle_free(data);
+    owner = data = nullptr;
+    ++generation;
+  }
+  Il2CppObject* ready()
+  {
+    auto*         p        = ExistingSingleton(prefs);
+    bool          isLoaded = false, isLoading = true;
+    Il2CppObject* state = nullptr;
+    if (p) {
+      il2cpp_field_get_value(p, loaded, &isLoaded);
+      il2cpp_field_get_value(p, loading, &isLoading);
+      il2cpp_field_get_value(p, saved, &state);
+    }
+    if (!p || !state || !isLoaded || isLoading) {
+      if (owner || data)
+        invalidate();
+      return nullptr;
+    }
+    if (!owner || !data || il2cpp_gchandle_get_target(owner) != p || il2cpp_gchandle_get_target(data) != state) {
+      invalidate();
+      owner = il2cpp_gchandle_new_weakref(p, false);
+      data  = il2cpp_gchandle_new_weakref(state, false);
+      if (!owner || !data) {
+        invalidate();
+        return nullptr;
+      }
+    }
+    return p;
+  }
+};
+Binding& Backend()
 {
-  auto* field = il2cpp_class_get_field_from_name(object->klass, name);
-  if (!field || field->type->type != IL2CPP_TYPE_BOOLEAN || (field->type->attrs & FIELD_ATTRIBUTE_STATIC))
-    return false;
-  il2cpp_field_get_value(object, field, &value);
-  return true;
+  static Binding binding;
+  return binding;
 }
 
-bool ReadHidden(const MethodInfo* getter, Il2CppObject* manager, bool& hidden)
+ReadResult ReadConfirmation()
 {
+  auto& b = Backend();
+  if (!b.supported())
+    return {Availability::Unsupported};
+  auto* prefs = b.ready();
+  if (!prefs)
+    return {};
+  if (!b.key)
+    b.key = il2cpp_gchandle_new(reinterpret_cast<Il2CppObject*>(il2cpp_string_new(PreferenceKey)), false);
+  if (!b.key)
+    return {};
+  // FC's native property uses GetBool(key,false,true). Display reads must not insert
+  // a missing preference: preserve its default but explicitly pass shouldAddKey=false.
+  bool             defaultHidden = false, addKey = false;
+  void*            args[]    = {il2cpp_gchandle_get_target(b.key), &defaultHidden, &addKey};
   Il2CppException* exception = nullptr;
-  auto*            result    = il2cpp_runtime_invoke(getter, manager, nullptr, &exception);
-  if (exception || !result)
-    return false;
-  hidden = *static_cast<bool*>(il2cpp_object_unbox(result));
-  return true;
+  auto*            value     = il2cpp_runtime_invoke(b.get, prefs, args, &exception);
+  if (exception || !value)
+    return {};
+  return ReadResult::Known(!*static_cast<bool*>(il2cpp_object_unbox(value)), b.generation);
+}
+ApplyResult WriteConfirmation(bool enabled, std::uint64_t expectedGeneration)
+{
+  auto& b = Backend();
+  if (!b.supported() || !b.ready() || b.generation != expectedGeneration)
+    return ApplyResult::Rejected;
+  auto* manager = ExistingSingleton(b.fc);
+  if (!manager)
+    return ApplyResult::Rejected;
+  bool             hidden    = !enabled;
+  void*            args[]    = {&hidden};
+  Il2CppException* exception = nullptr;
+  il2cpp_runtime_invoke(b.set, manager, args, &exception);
+  return exception ? ApplyResult::Unverified : ApplyResult::Applied;
+}
+} // namespace
+
+mod_settings::BooleanSetting& FleetCommanderConfirmationSetting()
+{
+  static mod_settings::BooleanSetting setting({"community_mod.fc_ability_confirmation",
+                                               "[MOD] Confirm Fleet Commander abilities", ReadConfirmation,
+                                               WriteConfirmation});
+  return setting;
 }
 
-} // namespace
+void InvalidateFleetCommanderConfirmationSession()
+{
+  // P2 must connect this to account/context lifecycle before retaining UI snapshots.
+  FleetCommanderConfirmationSetting().InvalidateSession();
+  Backend().invalidate();
+}
 
 void EnableFleetCommanderAbilityConfirmation()
 {
-  auto prefs_class =
-      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.PersistentPrefs", "PersistentPrefsManager");
-  auto  fc_class = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.FleetCommander", "FleetCommanderManager");
-  auto* prefs    = ExistingSingleton(prefs_class);
-  auto* manager  = ExistingSingleton(fc_class);
-  bool  loaded   = false;
-  bool  loading  = true;
-  if (!prefs || !manager || !ReadBoolField(prefs, "_isCloudFileLoaded", loaded)
-      || !ReadBoolField(prefs, "_isLoading", loading) || !loaded || loading) {
-    spdlog::warn("[FCConfirmation] Reset unavailable: account preferences are not ready; try again after loading");
-    return;
+  auto&      setting = FleetCommanderConfirmationSetting();
+  const auto result  = setting.SetFromUser(true, setting.Observe());
+  using mod_settings::Outcome;
+  switch (result.outcome) {
+    case Outcome::AppliedVerified:
+      spdlog::info("[FCConfirmation] Fleet Commander ability confirmation enabled; cloud persistence game-managed");
+      break;
+    case Outcome::Unchanged:
+      spdlog::info("[FCConfirmation] Fleet Commander ability confirmation is already enabled");
+      break;
+    default:
+      spdlog::warn("[FCConfirmation] Confirmation recovery not verified (status={}); retry after loading",
+                   static_cast<int>(result.outcome));
+      break;
   }
-
-  const auto* getter = fc_class.GetMethodInfo("get_HideFleetCommanderAbilityUseConfirmationHidden", 0);
-  const auto* setter = fc_class.GetMethodInfo("set_HideFleetCommanderAbilityUseConfirmationHidden", 1);
-  if (!getter || !setter || getter->return_type->type != IL2CPP_TYPE_BOOLEAN || getter->return_type->byref
-      || setter->return_type->type != IL2CPP_TYPE_VOID || setter->parameters[0]->type != IL2CPP_TYPE_BOOLEAN
-      || setter->parameters[0]->byref || (getter->flags & METHOD_ATTRIBUTE_STATIC)
-      || (setter->flags & METHOD_ATTRIBUTE_STATIC)) {
-    spdlog::error("[FCConfirmation] Reset unavailable: client confirmation methods are missing or incompatible");
-    return;
-  }
-
-  bool hidden = false;
-  if (!ReadHidden(getter, manager, hidden)) {
-    spdlog::error("[FCConfirmation] Could not read confirmation preference; no reset attempted");
-    return;
-  }
-  spdlog::info("[FCConfirmation] Before reset: hide_fcaa_use_confirmation={}", hidden);
-  if (!hidden) {
-    spdlog::info("[FCConfirmation] Fleet Commander ability confirmation is already enabled");
-    return;
-  }
-
-  // Use the same client setter as the preference UI. Never activate an ability or force a cloud upload.
-  bool             hide_confirmation = false;
-  void*            args[]            = {&hide_confirmation};
-  Il2CppException* exception         = nullptr;
-  il2cpp_runtime_invoke(setter, manager, args, &exception);
-  if (exception) {
-    spdlog::error("[FCConfirmation] Client setter failed; confirmation state is unverified");
-    return;
-  }
-  if (!ReadHidden(getter, manager, hidden) || hidden) {
-    spdlog::error("[FCConfirmation] Reset readback failed; confirmation state is unverified");
-    return;
-  }
-  spdlog::info("[FCConfirmation] Fleet Commander ability confirmation enabled (hide=false); cloud persistence pending");
 }

--- a/mods/src/patches/parts/fc_confirmation_reset.h
+++ b/mods/src/patches/parts/fc_confirmation_reset.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// One-way recovery action, called on the game thread by the hotkey dispatcher.
+void EnableFleetCommanderAbilityConfirmation();

--- a/mods/src/patches/parts/fc_confirmation_reset.h
+++ b/mods/src/patches/parts/fc_confirmation_reset.h
@@ -4,9 +4,6 @@ namespace mod_settings
 {
 class BooleanSetting;
 }
-// Game-thread API shared by the recovery shortcut and the forthcoming settings UI.
+// Game-thread preference adapter for the native confirmation settings UI.
 mod_settings::BooleanSetting& FleetCommanderConfirmationSetting();
 void                          InvalidateFleetCommanderConfirmationSession();
-
-// One-way recovery action, called on the game thread by the hotkey dispatcher.
-void EnableFleetCommanderAbilityConfirmation();

--- a/mods/src/patches/parts/fc_confirmation_reset.h
+++ b/mods/src/patches/parts/fc_confirmation_reset.h
@@ -1,4 +1,12 @@
 #pragma once
 
+namespace mod_settings
+{
+class BooleanSetting;
+}
+// Game-thread API shared by the recovery shortcut and the forthcoming settings UI.
+mod_settings::BooleanSetting& FleetCommanderConfirmationSetting();
+void                          InvalidateFleetCommanderConfirmationSession();
+
 // One-way recovery action, called on the game thread by the hotkey dispatcher.
 void EnableFleetCommanderAbilityConfirmation();

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -40,6 +40,7 @@
 #include "patches/mapkey.h"
 #include "patches/parts/daily_faction_bulk_claim.h"
 #include "patches/parts/focus_search.h"
+#include "patches/parts/fc_confirmation_reset.h"
 #include "str_utils.h"
 
 #include <il2cpp-tabledefs.h>
@@ -586,6 +587,11 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
 
   if (!is_in_chat) {
     if (!Key::IsInputFocused()) {
+      if (MapKey::IsDown(GameFunction::EnableFcAbilityConfirmation)) {
+        EnableFleetCommanderAbilityConfirmation();
+        return;
+      }
+
       if (MapKey::IsDown(GameFunction::SelectCurrent)) {
         auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();
         if (fleet_bar) {

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -40,7 +40,6 @@
 #include "patches/mapkey.h"
 #include "patches/parts/daily_faction_bulk_claim.h"
 #include "patches/parts/focus_search.h"
-#include "patches/parts/fc_confirmation_reset.h"
 #include "str_utils.h"
 
 #include <il2cpp-tabledefs.h>
@@ -587,10 +586,6 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
 
   if (!is_in_chat) {
     if (!Key::IsInputFocused()) {
-      if (MapKey::IsDown(GameFunction::EnableFcAbilityConfirmation)) {
-        EnableFleetCommanderAbilityConfirmation();
-        return;
-      }
 
       if (MapKey::IsDown(GameFunction::SelectCurrent)) {
         auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();

--- a/mods/src/patches/parts/mod_confirmation_settings.cc
+++ b/mods/src/patches/parts/mod_confirmation_settings.cc
@@ -411,6 +411,9 @@ void Render(View& view, auto original, Il2CppObject* widget)
   original(widget);
   Root        label(Target(view.label));
   std::string text = view.state.setting().label();
+  // The native row has limited label width: "Change not applied; try again" was
+  // visibly truncated after "; tr" alongside the FC label. Keep these suffixes
+  // short; recheck the full label at supported UI scales when changing wording.
   if (!view.state.value())
     text += " — Reopen to retry";
   else if (view.state.failed())

--- a/mods/src/patches/parts/mod_confirmation_settings.cc
+++ b/mods/src/patches/parts/mod_confirmation_settings.cc
@@ -1,0 +1,640 @@
+#include "fc_confirmation_reset.h"
+#include "settings/boolean_view.h"
+
+// Native extents are checked against Windows unwind records. Other platforms
+// keep the shared FC shortcut until equivalent UI hook evidence is available.
+#if defined(_WIN32) && defined(_M_X64)
+#include "settings/native_boolean_callback.h"
+#include <Windows.h>
+#include <array>
+#include <cstring>
+#include <il2cpp/il2cpp_helper.h>
+#include <spdlog/spdlog.h>
+#include <spud/detour.h>
+#include <stdexcept>
+#include <thread>
+
+namespace
+{
+using namespace mod_settings;
+constexpr const char*      CategoryKey = "game_settings_category_7";
+constexpr std::size_t      ViewLimit   = 8;
+bool                       active      = false;
+bool                       installing  = false;
+bool                       warned      = false;
+std::thread::id            uiThread;
+NativeCallback<bool>       getter;
+NativeCallback<void, bool> setter;
+NativeCallback<int>        query;
+
+void Warn()
+{
+  if (!warned) {
+    warned = true;
+    spdlog::warn("[ModSettings] Native confirmation UI unavailable; FC recovery shortcut remains independent");
+  }
+}
+
+struct Root {
+  Il2CppGCHandle handle = nullptr;
+  explicit Root(Il2CppObject* object, bool weak = false)
+  {
+    if (object)
+      handle = weak ? il2cpp_gchandle_new_weakref(object, false) : il2cpp_gchandle_new(object, false);
+    if (object && !handle)
+      throw std::runtime_error("settings root");
+  }
+  ~Root()
+  {
+    if (handle)
+      il2cpp_gchandle_free(handle);
+  }
+  Root(const Root&) = delete;
+  Il2CppObject* get() const
+  { return handle ? il2cpp_gchandle_get_target(handle) : nullptr; }
+};
+
+bool Type(const Il2CppType* type, int expected)
+{ return type && !type->byref && type->type == expected; }
+bool Instance(const MethodInfo* method, int count, int result)
+{
+  return method && method->methodPointer && method->invoker_method && !(method->flags & METHOD_ATTRIBUTE_STATIC)
+         && method->parameters_count == count && Type(method->return_type, result)
+         && !method->has_full_generic_sharing_signature;
+}
+bool Reference(const Il2CppType* type)
+{
+  return Type(type, IL2CPP_TYPE_CLASS) || Type(type, IL2CPP_TYPE_GENERICINST) || Type(type, IL2CPP_TYPE_OBJECT)
+         || Type(type, IL2CPP_TYPE_STRING);
+}
+FieldInfo* Field(Il2CppClass* cls, const char* name)
+{
+  auto* field = cls ? il2cpp_class_get_field_from_name(cls, name) : nullptr;
+  if (!field || !Reference(field->type) || (field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+    throw std::runtime_error("settings reference field");
+  return field;
+}
+Il2CppObject* ReadField(Il2CppObject* object, FieldInfo* field)
+{
+  Il2CppObject* value = nullptr;
+  if (object)
+    il2cpp_field_get_value(object, field, &value);
+  return value;
+}
+Il2CppObject* Invoke(const MethodInfo* method, Il2CppObject* object, void** args = nullptr)
+{
+  if (!method || !object)
+    throw std::runtime_error("settings invocation");
+  Il2CppException* error  = nullptr;
+  auto*            result = il2cpp_runtime_invoke(method, object, args, &error);
+  if (error)
+    throw std::runtime_error("settings managed exception");
+  return result;
+}
+// Bounded discovery helpers used only while opening a page or binding a row.
+Il2CppObject* Call(Il2CppObject* object, const char* name, int count = 0, void** args = nullptr)
+{ return Invoke(object ? il2cpp_class_get_method_from_name(object->klass, name, count) : nullptr, object, args); }
+bool Boolean(Il2CppObject* boxed)
+{
+  if (!boxed || !Type(il2cpp_class_get_type(boxed->klass), IL2CPP_TYPE_BOOLEAN))
+    throw std::runtime_error("settings boolean result");
+  return *static_cast<bool*>(il2cpp_object_unbox(boxed));
+}
+bool Equals(Il2CppObject* value, const char* ascii)
+{
+  if (!value || !Type(il2cpp_class_get_type(value->klass), IL2CPP_TYPE_STRING))
+    return false;
+  auto*      text   = reinterpret_cast<Il2CppString*>(value);
+  const auto length = std::strlen(ascii);
+  if (il2cpp_string_length(text) != length)
+    return false;
+  auto* chars = il2cpp_string_chars(text);
+  for (std::size_t i = 0; i < length; ++i)
+    if (chars[i] != static_cast<unsigned char>(ascii[i]))
+      return false;
+  return true;
+}
+
+struct Metadata {
+  IL2CppClassHelper director =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.GameSettings", "SettingsSectionDirector");
+  IL2CppClassHelper widget =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.GameSettings", "ToggleOptionWidget");
+  IL2CppClassHelper context = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.GameSettings", "SettingsContext");
+  IL2CppClassHelper row = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.GameSettings", "ToggleOptionContext");
+  IL2CppClassHelper prefs =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.PersistentPrefs", "PersistentPrefsManager");
+  const MethodInfo* addGeneral  = director.GetMethodInfo("AddGeneralSettings", 1);
+  const MethodInfo* addToggle   = context.GetMethodInfo("AddToggle", 4);
+  const MethodInfo* refresh     = widget.GetMethodInfo("SetWidgetData", 0);
+  const MethodInfo* changed     = widget.GetMethodInfo("OnToggleValueChanged", 1);
+  const MethodInfo* release     = widget.GetMethodInfo("OnAboutToReleaseContext", 0);
+  const MethodInfo* reload      = prefs.GetMethodInfo("RegisterEvents", 0);
+  const MethodInfo* session     = prefs.GetMethodInfo("GameSessionStartedEventHandler", 0);
+  const MethodInfo* load        = prefs.GetMethodInfo("LoadPersistentPrefsFromCloud", 0);
+  const MethodInfo* getContext  = widget.GetMethodInfo("get_Context", 0);
+  const MethodInfo* querySetter = row.GetMethodInfo("set_QueryOptionState", 1);
+  FieldInfo*        queryField  = Field(row.get_cls(), "<QueryOptionState>k__BackingField");
+  FieldInfo*        labelField  = Field(widget.get_cls(), "_label");
+  FieldInfo*        toggleField = Field(widget.get_cls(), "_toggle");
+  FieldInfo*        stateField  = Field(widget.get_cls(), "_toggleStateAnimator");
+};
+Metadata& Meta()
+{
+  static Metadata metadata;
+  return metadata;
+}
+
+// Fixed weak records: no page, context, delegate, or account is retained by UI
+// bookkeeping. Records are released on native unbind and reclaimed on next bind
+// if Unity destroys a widget without sending that notification.
+struct View {
+  Il2CppGCHandle                widget = nullptr, context = nullptr, label = nullptr;
+  std::array<Il2CppGCHandle, 2> indicators{};
+  std::array<bool, 2>           activeBefore{};
+  bool                          overridden          = false;
+  bool                          hidden              = false;
+  bool                          rendering           = false;
+  bool                          preserveNextRefresh = false;
+  BooleanView                   state{FleetCommanderConfirmationSetting()};
+};
+std::array<View, ViewLimit>& Views()
+{
+  static std::array<View, ViewLimit> views;
+  return views;
+}
+Il2CppObject* Target(Il2CppGCHandle handle)
+{ return handle ? il2cpp_gchandle_get_target(handle) : nullptr; }
+void Free(Il2CppGCHandle& handle)
+{
+  if (handle)
+    il2cpp_gchandle_free(handle);
+  handle = nullptr;
+}
+void SetActive(Il2CppObject* object, bool value)
+{
+  void* args[] = {&value};
+  Call(object, "SetActive", 1, args);
+}
+void Restore(View& view)
+{
+  if (view.overridden) {
+    if (auto* label = Target(view.label))
+      Call(label, "ClearTextOverride");
+    view.overridden = false;
+  }
+  if (view.hidden) {
+    for (std::size_t i = 0; i < view.indicators.size(); ++i)
+      if (auto* object = Target(view.indicators[i]))
+        SetActive(object, view.activeBefore[i]);
+    view.hidden = false;
+  }
+}
+void Clear(View& view)
+{
+  try {
+    Restore(view);
+  } catch (...) {
+    Warn();
+  }
+  Free(view.widget);
+  Free(view.context);
+  Free(view.label);
+  for (auto& handle : view.indicators)
+    Free(handle);
+  view.state.Unbind();
+  view.overridden = view.hidden = view.preserveNextRefresh = false;
+}
+View* Find(Il2CppObject* widget)
+{
+  for (auto& view : Views())
+    if (Target(view.widget) == widget)
+      return &view;
+  return nullptr;
+}
+bool Owned(Il2CppObject* context)
+{
+  if (!context || context->klass != Meta().row.get_cls())
+    return false;
+  auto* callback = reinterpret_cast<Il2CppDelegate*>(ReadField(context, Meta().queryField));
+  return callback && callback->method == query.method() && callback->method_ptr == query.method()->methodPointer;
+}
+bool ChildOf(Il2CppObject* transform, Il2CppObject* parent)
+{
+  void* args[] = {parent};
+  return Boolean(Call(transform, "IsChildOf", 1, args));
+}
+View& Track(Il2CppObject* widget, Il2CppObject* context)
+{
+  for (auto& view : Views()) {
+    if (Target(view.widget))
+      continue;
+    Clear(view);
+    Root                         label(ReadField(widget, Meta().labelField));
+    Root                         widgetTransform(Call(widget, "get_transform"));
+    Root                         labelTransform(Call(label.get(), "get_transform"));
+    std::array<Il2CppObject*, 2> indicators{ReadField(widget, Meta().toggleField),
+                                            ReadField(widget, Meta().stateField)};
+    Root                         first(Call(indicators[0], "get_gameObject"));
+    Root                         second(Call(indicators[1], "get_gameObject"));
+    indicators = {first.get(), second.get()};
+    // Never hide the row or an ancestor of its label to suppress unknown ON/OFF.
+    // An unsupported prefab is rejected before any override is applied.
+    for (auto* indicator : indicators) {
+      Root transform(Call(indicator, "get_transform"));
+      if (transform.get() == widgetTransform.get() || !ChildOf(transform.get(), widgetTransform.get())
+          || ChildOf(labelTransform.get(), transform.get()))
+        throw std::runtime_error("settings indicator hierarchy");
+    }
+    try {
+      auto weak = [](Il2CppObject* object) {
+        auto handle = il2cpp_gchandle_new_weakref(object, false);
+        if (!handle)
+          throw std::runtime_error("settings weak root");
+        return handle;
+      };
+      view.widget  = weak(widget);
+      view.context = weak(context);
+      view.label   = weak(label.get());
+      for (std::size_t i = 0; i < indicators.size(); ++i)
+        view.indicators[i] = weak(indicators[i]);
+    } catch (...) {
+      Clear(view);
+      throw;
+    }
+    return view;
+  }
+  throw std::runtime_error("settings view capacity");
+}
+
+View* renderingView = nullptr;
+bool  GetEnabled(Il2CppObject*, const MethodInfo*)
+{
+  // Native bool signatures cannot express unknown. Only the owned render scope
+  // consumes this placeholder; its indicators are suppressed when value is empty.
+  return renderingView ? renderingView->state.value().value_or(false) : false;
+}
+void SetEnabled(Il2CppObject*, bool, const MethodInfo*)
+{
+  // Deliberately inert. Only OnToggleValueChanged with a live view snapshot can
+  // authorize a write; rendering and reflection cannot mutate game preferences.
+}
+int QueryState(Il2CppObject*, const MethodInfo*)
+{ return 0; }
+
+Il2CppObject* MakeDelegate(Il2CppClass* cls, Il2CppObject* director, const MethodInfo* method)
+{
+  const auto* ctor = cls ? il2cpp_class_get_method_from_name(cls, ".ctor", 2) : nullptr;
+  if (!Instance(ctor, 2, IL2CPP_TYPE_VOID) || !Reference(ctor->parameters[0])
+      || !Type(ctor->parameters[1], IL2CPP_TYPE_I) || !method)
+    throw std::runtime_error("settings delegate constructor");
+  const auto* invoke = il2cpp_class_get_method_from_name(cls, "Invoke", method->parameters_count);
+  auto*       parent = il2cpp_class_get_parent(cls);
+  if (!parent || std::strcmp(il2cpp_class_get_name(parent), "MulticastDelegate") != 0
+      || std::strcmp(il2cpp_class_get_namespace(parent), "System") != 0 || !invoke || invoke->return_type->byref
+      || (invoke->flags & METHOD_ATTRIBUTE_STATIC)
+      || il2cpp_class_from_type(invoke->return_type) != il2cpp_class_from_type(method->return_type)
+      || !il2cpp_class_is_assignable_from(method->klass, director->klass))
+    throw std::runtime_error("settings delegate signature");
+  for (int i = 0; i < method->parameters_count; ++i)
+    if (invoke->parameters[i]->byref
+        || il2cpp_class_from_type(invoke->parameters[i]) != il2cpp_class_from_type(method->parameters[i]))
+      throw std::runtime_error("settings delegate parameter");
+  Root  object(il2cpp_object_new(cls));
+  void* args[] = {director, &method};
+  Invoke(ctor, object.get(), args);
+  auto* delegate = reinterpret_cast<Il2CppDelegate*>(object.get());
+  if (delegate->target != director || delegate->invoke_impl_this != director || delegate->method != method)
+    throw std::runtime_error("settings closed delegate");
+  delegate->method_ptr  = method->methodPointer;
+  delegate->invoke_impl = method->methodPointer;
+  return object.get();
+}
+
+int Count(Il2CppObject* list)
+{
+  Root value(Call(list, "get_Count"));
+  if (!value.get() || !Type(il2cpp_class_get_type(value.get()->klass), IL2CPP_TYPE_I4))
+    throw std::runtime_error("settings child count");
+  const int count = *static_cast<int*>(il2cpp_object_unbox(value.get()));
+  if (count < 0 || count > 128)
+    throw std::runtime_error("settings child bound");
+  return count;
+}
+Il2CppObject* Item(Il2CppObject* list, int index)
+{
+  void* args[] = {&index};
+  return Call(list, "get_Item", 1, args);
+}
+bool HasLabel(Il2CppObject* row, const char* id)
+{
+  Root label(Call(row, "get_LabelContext"));
+  return Equals(Call(label.get(), "get_Identifier"), id);
+}
+Il2CppObject* Category(Il2CppObject* container, int depth, int& remaining)
+{
+  if (!container || depth > 3 || --remaining < 0)
+    return nullptr;
+  if (HasLabel(container, CategoryKey))
+    return container;
+  if (!il2cpp_class_get_method_from_name(container->klass, "get_Children", 0))
+    return nullptr;
+  Root children(Call(container, "get_Children"));
+  for (int i = 0, count = Count(children.get()); i < count && remaining > 0; ++i)
+    if (auto* found = Category(Item(children.get(), i), depth + 1, remaining))
+      return found;
+  return nullptr;
+}
+void AddRow(Il2CppObject* director, Il2CppObject* context)
+{
+  auto& setting = FleetCommanderConfirmationSetting();
+  if (setting.Observe().state.availability == Availability::Unsupported)
+    return;
+  Root root(Call(context, "get_RootOption"));
+  int  remaining = 128;
+  Root category(Category(root.get(), 0, remaining));
+  if (!category.get())
+    throw std::runtime_error("settings confirmation category");
+  Root      children(Call(category.get(), "get_Children"));
+  const int before = Count(children.get());
+  for (int i = 0; i < before; ++i)
+    if (Owned(Item(children.get(), i)) || HasLabel(Item(children.get(), i), setting.id().c_str()))
+      return;
+  if (before == 128)
+    throw std::runtime_error("settings category full");
+  auto& m = Meta();
+  Root  get(MakeDelegate(il2cpp_class_from_type(m.addToggle->parameters[2]), director, getter.method()));
+  Root  set(MakeDelegate(il2cpp_class_from_type(m.addToggle->parameters[3]), director, setter.method()));
+  Root  state(MakeDelegate(il2cpp_class_from_type(m.querySetter->parameters[0]), director, query.method()));
+  Root  label(reinterpret_cast<Il2CppObject*>(il2cpp_string_new(setting.id().c_str())));
+  void* args[] = {category.get(), label.get(), get.get(), set.get()};
+  Invoke(m.addToggle, context, args);
+  if (Count(children.get()) != before + 1)
+    throw std::runtime_error("settings row insertion");
+  Root row(Item(children.get(), before));
+  try {
+    if (row.get()->klass != m.row.get_cls() || !HasLabel(row.get(), setting.id().c_str()))
+      throw std::runtime_error("settings row identity");
+    void* stateArgs[] = {state.get()};
+    Invoke(m.querySetter, row.get(), stateArgs);
+  } catch (...) {
+    void* removeArgs[] = {row.get()};
+    Call(category.get(), "RemoveChild", 1, removeArgs);
+    throw;
+  }
+}
+
+void Render(View& view, auto original, Il2CppObject* widget)
+{
+  if (view.rendering)
+    return;
+  struct Scope {
+    View&                       view;
+    View*                       previous;
+    BooleanSetting::RenderScope suppress;
+    Scope(View& view)
+        : view(view)
+        , previous(renderingView)
+        , suppress(view.state.setting())
+    {
+      view.rendering = true;
+      renderingView  = &view;
+    }
+    ~Scope()
+    {
+      renderingView  = previous;
+      view.rendering = false;
+    }
+  } scope(view);
+  Restore(view);
+  original(widget);
+  Root        label(Target(view.label));
+  std::string text = view.state.setting().label();
+  if (!view.state.value())
+    text += " — Unavailable; reopen settings";
+  else if (view.state.failed())
+    text += " — Change not applied; try again";
+  Root  message(reinterpret_cast<Il2CppObject*>(il2cpp_string_new(text.c_str())));
+  void* args[] = {message.get()};
+  Call(label.get(), "OverrideLocalizedText", 1, args);
+  view.overridden = true;
+  if (!view.state.value()) {
+    // Capture all native values first (the two components may share a node).
+    for (std::size_t i = 0; i < view.indicators.size(); ++i)
+      view.activeBefore[i] = Boolean(Call(Target(view.indicators[i]), "get_activeSelf"));
+    view.hidden = true;
+    for (auto handle : view.indicators)
+      SetActive(Target(handle), false);
+  }
+}
+void HideUnsupported(Il2CppObject* widget)
+{
+  try {
+    Root object(Call(widget, "get_gameObject"));
+    SetActive(object.get(), false);
+  } catch (...) {
+  }
+  Warn();
+}
+bool OnThread()
+{ return active && std::this_thread::get_id() == uiThread; }
+
+void AddGeneralHook(auto original, Il2CppObject* director, Il2CppObject* context)
+{
+  original(director, context);
+  if (!OnThread())
+    return;
+  try {
+    AddRow(director, context);
+  } catch (...) {
+    Warn();
+  }
+}
+void RefreshHook(auto original, Il2CppObject* widget)
+{
+  if (!OnThread()) {
+    original(widget);
+    return;
+  }
+  bool owned = false;
+  try {
+    Root context(Invoke(Meta().getContext, widget));
+    owned      = Owned(context.get());
+    auto* view = Find(widget);
+    if (view && view->rendering)
+      return;
+    if (view && Target(view->context) != context.get()) {
+      Clear(*view);
+      view = nullptr;
+    }
+    if (!owned) {
+      if (view)
+        Clear(*view);
+    } else {
+      if (!view)
+        view = &Track(widget, context.get());
+      if (!view->preserveNextRefresh)
+        view->state.Bind();
+      view->preserveNextRefresh = false;
+      Render(*view, original, widget);
+      return;
+    }
+  } catch (...) {
+    if (owned) {
+      HideUnsupported(widget);
+      return;
+    }
+    Warn();
+  }
+  original(widget);
+}
+void ChangedHook(auto original, Il2CppObject* widget, bool desired)
+{
+  if (!OnThread()) {
+    original(widget, desired);
+    return;
+  }
+  bool owned = false;
+  try {
+    Root context(Invoke(Meta().getContext, widget));
+    owned = Owned(context.get());
+    if (owned) {
+      auto* view = Find(widget);
+      if (!view || view->rendering || Target(view->context) != context.get())
+        return;
+      auto result = view->state.Request(desired);
+      if (result.outcome == Outcome::Suppressed || result.outcome == Outcome::Busy)
+        return;
+      // Refresh through the hook once, preserving the write result. A fresh Bind
+      // here would erase an unverified outcome merely because a later read works.
+      view->preserveNextRefresh = true;
+      Invoke(Meta().refresh, widget);
+      if (result.outcome == Outcome::AppliedVerified || result.outcome == Outcome::Unchanged) {
+        for (auto& other : Views()) {
+          if (&other == view)
+            continue;
+          Root otherWidget(Target(other.widget));
+          if (!otherWidget.get())
+            continue;
+          Root otherContext(Invoke(Meta().getContext, otherWidget.get()));
+          if (Target(other.context) != otherContext.get() || !Owned(otherContext.get()))
+            continue;
+          Invoke(Meta().refresh, otherWidget.get());
+        }
+      }
+      return;
+    }
+  } catch (...) {
+    if (owned) {
+      HideUnsupported(widget);
+      return;
+    }
+    Warn();
+  }
+  original(widget, desired);
+}
+void ReleaseHook(auto original, Il2CppObject* widget)
+{
+  if (OnThread()) {
+    try {
+      if (auto* view = Find(widget))
+        Clear(*view);
+    } catch (...) {
+      Warn();
+    }
+  }
+  original(widget);
+}
+void Invalidate()
+{
+  InvalidateFleetCommanderConfirmationSession();
+  for (auto& view : Views()) {
+    view.state.Invalidate();
+    // Re-rendering during a native account transition can read the old account.
+    // Hide the indicators immediately; next explicit bind may establish readiness.
+    if (auto* widget = Target(view.widget)) {
+      try {
+        Render(view, [](Il2CppObject*) {}, widget);
+      } catch (...) {
+        HideUnsupported(widget);
+      }
+    }
+  }
+}
+void SessionBoundary(auto original, Il2CppObject* owner)
+{
+  if (OnThread()) {
+    try {
+      Invalidate();
+    } catch (...) {
+      Warn();
+    }
+  }
+  original(owner);
+}
+void ReloadHook(auto original, Il2CppObject* owner)
+{ SessionBoundary(original, owner); }
+void SessionHook(auto original, Il2CppObject* owner)
+{ SessionBoundary(original, owner); }
+void LoadHook(auto original, Il2CppObject* owner)
+{ SessionBoundary(original, owner); }
+bool Extent(const MethodInfo* method)
+{
+  if (!method || !method->methodPointer)
+    return false;
+  DWORD64    base    = 0;
+  const auto address = reinterpret_cast<DWORD64>(method->methodPointer);
+  auto*      entry   = RtlLookupFunctionEntry(address, &base, nullptr);
+  // x64 SPUD needs 14 bytes; 64-byte minimum plus exact function entry rejects
+  // shared tiny accessors/thunks. Only Windows x64 is enabled by this adapter.
+  return entry && base + entry->BeginAddress == address && entry->EndAddress - entry->BeginAddress >= 64;
+}
+} // namespace
+
+void InstallModConfirmationSettings()
+{
+  if (active || installing)
+    return;
+  installing = true;
+  try {
+    auto&            m = Meta();
+    const std::array hooks{m.addGeneral, m.refresh, m.changed, m.release, m.reload, m.session, m.load};
+    for (std::size_t i = 0; i < hooks.size(); ++i) {
+      if (!Instance(hooks[i], i == 0 || i == 2 ? 1 : 0, IL2CPP_TYPE_VOID) || !Extent(hooks[i]))
+        throw std::runtime_error("settings hook metadata/extent");
+      for (std::size_t j = 0; j < i; ++j)
+        if (hooks[i]->methodPointer == hooks[j]->methodPointer)
+          throw std::runtime_error("settings shared hook");
+    }
+    const auto* getSchema   = m.director.GetMethodInfo("IsBorgCubeCuttingBeamConfirmationOn", 0);
+    const auto* setSchema   = m.director.GetMethodInfo("ToggleBorgCubeCuttingBeamConfirmation", 1);
+    const auto* querySchema = m.director.GetMethodInfo("QueryShouldShowGenericPcSetting", 0);
+    if (!Instance(getSchema, 0, IL2CPP_TYPE_BOOLEAN) || !Instance(setSchema, 1, IL2CPP_TYPE_VOID)
+        || !Type(setSchema->parameters[0], IL2CPP_TYPE_BOOLEAN) || !querySchema
+        || !il2cpp_class_is_enum(il2cpp_class_from_type(querySchema->return_type))
+        || !Type(il2cpp_class_enum_basetype(il2cpp_class_from_type(querySchema->return_type)), IL2CPP_TYPE_I4)
+        || !Instance(querySchema, 0, IL2CPP_TYPE_VALUETYPE) || !Instance(m.addToggle, 4, IL2CPP_TYPE_VOID)
+        || !Type(m.addToggle->parameters[1], IL2CPP_TYPE_STRING) || !Reference(m.addToggle->parameters[0])
+        || !Reference(m.addToggle->parameters[2]) || !Reference(m.addToggle->parameters[3])
+        || !Type(m.changed->parameters[0], IL2CPP_TYPE_BOOLEAN) || !Reference(m.addGeneral->parameters[0])
+        || !m.getContext || !Reference(m.getContext->return_type) || !Instance(m.querySetter, 1, IL2CPP_TYPE_VOID)
+        || !Reference(m.querySetter->parameters[0]) || !getter.Initialize(getSchema, GetEnabled)
+        || !setter.Initialize(setSchema, SetEnabled) || !query.Initialize(querySchema, QueryState))
+      throw std::runtime_error("settings callback schema");
+    uiThread = std::this_thread::get_id();
+    SPUD_STATIC_DETOUR(m.refresh->methodPointer, RefreshHook);
+    SPUD_STATIC_DETOUR(m.changed->methodPointer, ChangedHook);
+    SPUD_STATIC_DETOUR(m.release->methodPointer, ReleaseHook);
+    SPUD_STATIC_DETOUR(m.reload->methodPointer, ReloadHook);
+    SPUD_STATIC_DETOUR(m.session->methodPointer, SessionHook);
+    SPUD_STATIC_DETOUR(m.load->methodPointer, LoadHook);
+    SPUD_STATIC_DETOUR(m.addGeneral->methodPointer, AddGeneralHook);
+    active = true;
+    spdlog::info("[ModSettings] Native FC confirmation adapter installed (Windows x64)");
+  } catch (...) {
+    Warn();
+  }
+}
+#else
+void InstallModConfirmationSettings() {}
+#endif

--- a/mods/src/patches/parts/mod_confirmation_settings.cc
+++ b/mods/src/patches/parts/mod_confirmation_settings.cc
@@ -267,7 +267,8 @@ View& Track(Il2CppObject* widget, Il2CppObject* context)
   throw std::runtime_error("settings view capacity");
 }
 
-View* renderingView = nullptr;
+View* renderingView  = nullptr;
+View* requestingView = nullptr;
 bool  GetEnabled(Il2CppObject*, const MethodInfo*)
 {
   // Native bool signatures cannot express unknown. Only the owned render scope
@@ -329,7 +330,7 @@ Il2CppObject* Item(Il2CppObject* list, int index)
 bool HasLabel(Il2CppObject* row, const char* id)
 {
   Root label(Call(row, "get_LabelContext"));
-  return Equals(Call(label.get(), "get_Identifier"), id);
+  return label.get() && Equals(Call(label.get(), "get_Identifier"), id);
 }
 Il2CppObject* Category(Il2CppObject* container, int depth, int& remaining)
 {
@@ -488,6 +489,26 @@ void RefreshHook(auto original, Il2CppObject* widget)
   }
   original(widget);
 }
+void RefreshViews()
+{
+  if (!OnThread())
+    return;
+  for (auto& view : Views()) {
+    if (&view == requestingView || view.rendering)
+      continue;
+    Root widget(Target(view.widget));
+    if (!widget.get())
+      continue;
+    try {
+      Root context(Invoke(Meta().getContext, widget.get()));
+      if (Target(view.context) != context.get() || !Owned(context.get()))
+        continue;
+      Invoke(Meta().refresh, widget.get());
+    } catch (...) {
+      HideUnsupported(widget.get());
+    }
+  }
+}
 void ChangedHook(auto original, Il2CppObject* widget, bool desired)
 {
   if (!OnThread()) {
@@ -502,6 +523,13 @@ void ChangedHook(auto original, Il2CppObject* widget, bool desired)
       auto* view = Find(widget);
       if (!view || view->rendering || Target(view->context) != context.get())
         return;
+      struct RequestScope {
+        View* previous = requestingView;
+        explicit RequestScope(View* view)
+        { requestingView = view; }
+        ~RequestScope()
+        { requestingView = previous; }
+      } requestScope(view);
       auto result = view->state.Request(desired);
       if (result.outcome == Outcome::Suppressed || result.outcome == Outcome::Busy)
         return;
@@ -509,19 +537,6 @@ void ChangedHook(auto original, Il2CppObject* widget, bool desired)
       // here would erase an unverified outcome merely because a later read works.
       view->preserveNextRefresh = true;
       Invoke(Meta().refresh, widget);
-      if (result.outcome == Outcome::AppliedVerified || result.outcome == Outcome::Unchanged) {
-        for (auto& other : Views()) {
-          if (&other == view)
-            continue;
-          Root otherWidget(Target(other.widget));
-          if (!otherWidget.get())
-            continue;
-          Root otherContext(Invoke(Meta().getContext, otherWidget.get()));
-          if (Target(other.context) != otherContext.get() || !Owned(otherContext.get()))
-            continue;
-          Invoke(Meta().refresh, otherWidget.get());
-        }
-      }
       return;
     }
   } catch (...) {
@@ -622,6 +637,8 @@ void InstallModConfirmationSettings()
         || !setter.Initialize(setSchema, SetEnabled) || !query.Initialize(querySchema, QueryState))
       throw std::runtime_error("settings callback schema");
     uiThread = std::this_thread::get_id();
+    if (!FleetCommanderConfirmationSetting().SetChangeObserver(RefreshViews))
+      throw std::runtime_error("settings observer ownership");
     SPUD_STATIC_DETOUR(m.refresh->methodPointer, RefreshHook);
     SPUD_STATIC_DETOUR(m.changed->methodPointer, ChangedHook);
     SPUD_STATIC_DETOUR(m.release->methodPointer, ReleaseHook);

--- a/mods/src/patches/parts/mod_confirmation_settings.cc
+++ b/mods/src/patches/parts/mod_confirmation_settings.cc
@@ -412,9 +412,9 @@ void Render(View& view, auto original, Il2CppObject* widget)
   Root        label(Target(view.label));
   std::string text = view.state.setting().label();
   if (!view.state.value())
-    text += " — Unavailable; reopen settings";
+    text += " — Reopen to retry";
   else if (view.state.failed())
-    text += " — Change not applied; try again";
+    text += " — Retry";
   Root  message(reinterpret_cast<Il2CppObject*>(il2cpp_string_new(text.c_str())));
   void* args[] = {message.get()};
   Call(label.get(), "OverrideLocalizedText", 1, args);

--- a/mods/src/patches/parts/mod_confirmation_settings.cc
+++ b/mods/src/patches/parts/mod_confirmation_settings.cc
@@ -600,7 +600,7 @@ bool Extent(const MethodInfo* method)
   DWORD64    base    = 0;
   const auto address = reinterpret_cast<DWORD64>(method->methodPointer);
   auto*      entry   = RtlLookupFunctionEntry(address, &base, nullptr);
-  // x64 SPUD needs 14 bytes; 64-byte minimum plus exact function entry rejects
+  // Bundled x64 SPUD reserves 24 bytes; the 64-byte minimum and exact entry reject
   // shared tiny accessors/thunks. Only Windows x64 is enabled by this adapter.
   return entry && base + entry->BeginAddress == address && entry->EndAddress - entry->BeginAddress >= 64;
 }

--- a/mods/src/patches/parts/mod_confirmation_settings.cc
+++ b/mods/src/patches/parts/mod_confirmation_settings.cc
@@ -2,7 +2,7 @@
 #include "settings/boolean_view.h"
 
 // Native extents are checked against Windows unwind records. Other platforms
-// keep the shared FC shortcut until equivalent UI hook evidence is available.
+// omit the native UI until equivalent hook evidence is available.
 #if defined(_WIN32) && defined(_M_X64)
 #include "settings/native_boolean_callback.h"
 #include <Windows.h>
@@ -31,7 +31,7 @@ void Warn()
 {
   if (!warned) {
     warned = true;
-    spdlog::warn("[ModSettings] Native confirmation UI unavailable; FC recovery shortcut remains independent");
+    spdlog::warn("[ModSettings] Native confirmation UI unavailable; no mod control added");
   }
 }
 

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -76,6 +76,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
 
   spdlog::set_level(log_level);
   spdlog::flush_on(log_level);
+  spud::set_detour_diagnostic_handler([](const char* message) { spdlog::error("[Spud] {}", message); });
 
 #if VERSION_PATCH
   if constexpr (sizeof(VERSION_COMMIT_HASH) > 1) {

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -48,6 +48,7 @@ void InstallDoubleClickAssignShipHooks();
 void InstallInstantWarpConfirmationHooks();
 void InstallForbiddenTechConfirmationHooks();
 void InstallAudioEventHooks();
+void InstallModConfirmationSettings();
 
 __int64 il2cpp_init_hook(auto original, const char* domain_name)
 {
@@ -151,6 +152,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"InstantWarpConfirm",   {InstallInstantWarpConfirmationHooks, &cfg.installInstantWarpConfirmationHooks}},
       {"ForbiddenTechConfirm", {InstallForbiddenTechConfirmationHooks, &cfg.auto_confirm_ft_upgrade}},
       {"AudioEvents",          {InstallAudioEventHooks,                 &cfg.installAudioEventHooks}},
+      {"ModConfirmationSettings", {InstallModConfirmationSettings, &cfg.installModConfirmationSettings}},
   };
   printf("il2cpp_init_hook(%s)\n", domain_name);
 

--- a/mods/src/settings/boolean_settings.h
+++ b/mods/src/settings/boolean_settings.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+namespace mod_settings
+{
+enum class Availability { Known, Unavailable, Unsupported };
+struct ReadResult {
+  Availability        availability = Availability::Unavailable;
+  std::optional<bool> value;
+  std::uint64_t       generation = 0;
+  static ReadResult   Known(bool value, std::uint64_t generation)
+  { return {Availability::Known, value, generation}; }
+  bool known() const
+  { return availability == Availability::Known && value.has_value() && generation != 0; }
+};
+enum class ApplyResult { Applied, Rejected, Unverified };
+enum class Outcome { AppliedVerified, Unchanged, Suppressed, Busy, Conflict, Rejected, Unverified };
+struct Definition {
+  std::string                 id;
+  std::string                 label;
+  std::function<ReadResult()> read;
+  // Adapter must revalidate its own generation immediately before mutation.
+  std::function<ApplyResult(bool, std::uint64_t)> write;
+};
+struct Snapshot {
+  ReadResult    state;
+  std::uint64_t revision = 0;
+  std::uint64_t epoch    = 0;
+  std::uint64_t owner    = 0;
+};
+struct WriteResult {
+  Outcome  outcome;
+  Snapshot snapshot;
+};
+
+// All calls, including scope destruction, belong to the constructing UI thread.
+// No timers, background work, locks, storage, or IL2CPP dependencies.
+class BooleanSetting
+{
+public:
+  explicit BooleanSetting(Definition definition)
+      : definition_(std::move(definition))
+  {
+  }
+  BooleanSetting(const BooleanSetting&)               = delete;
+  BooleanSetting&    operator=(const BooleanSetting&) = delete;
+  const std::string& id() const
+  { return definition_.id; }
+  const std::string& label() const
+  { return definition_.label; }
+
+  class RenderScope
+  {
+  public:
+    explicit RenderScope(BooleanSetting& setting)
+        : setting_(setting)
+    {
+      setting_.CheckThread();
+      ++setting_.render_depth_;
+    }
+    ~RenderScope()
+    { --setting_.render_depth_; }
+    RenderScope(const RenderScope&)            = delete;
+    RenderScope& operator=(const RenderScope&) = delete;
+
+  private:
+    BooleanSetting& setting_;
+  };
+
+  Snapshot Observe()
+  {
+    CheckThread();
+    if (observing_)
+      return {{}, current_.revision, epoch_, identity_};
+    struct Observing {
+      bool& flag;
+      Observing(bool& flag)
+          : flag(flag)
+      { flag = true; }
+      ~Observing()
+      { flag = false; }
+    } guard(observing_);
+    const auto read_epoch = epoch_;
+    ReadResult next;
+    try {
+      next = definition_.read();
+    } catch (...) {
+      next = {};
+    }
+    if (read_epoch != epoch_)
+      next = {};
+    if (!next.known()) {
+      next.value.reset();
+      next.generation = 0;
+      if (next.availability == Availability::Known)
+        next.availability = Availability::Unavailable;
+    }
+    if (next.availability != current_.state.availability || next.value != current_.state.value
+        || next.generation != current_.state.generation)
+      ++current_.revision;
+    current_.state = next;
+    current_.epoch = epoch_;
+    current_.owner = identity_;
+    return current_;
+  }
+
+  void InvalidateSession()
+  {
+    CheckThread();
+    ++epoch_;
+    current_ = {{}, current_.revision + 1, epoch_, identity_};
+  }
+
+  WriteResult SetFromUser(bool desired, const Snapshot& observed)
+  {
+    CheckThread();
+    if (render_depth_)
+      return {Outcome::Suppressed, current_};
+    if (applying_)
+      return {Outcome::Busy, current_};
+    // Cover read callbacks as well as the setter: neither can reenter application.
+    struct Applying {
+      bool& flag;
+      Applying(bool& flag)
+          : flag(flag)
+      { flag = true; }
+      ~Applying()
+      { flag = false; }
+    } guard(applying_);
+    const auto before = Observe();
+    if (!before.state.known())
+      return {Outcome::Rejected, before};
+    if (observed.owner != identity_ || !observed.state.known() || observed.epoch != before.epoch
+        || observed.revision != before.revision || observed.state.generation != before.state.generation
+        || observed.state.value != before.state.value)
+      return {Outcome::Conflict, before};
+    if (*before.state.value == desired)
+      return {Outcome::Unchanged, before};
+    ApplyResult applied = ApplyResult::Unverified;
+    try {
+      applied = definition_.write(desired, before.state.generation);
+    } catch (...) {
+    }
+    if (epoch_ != before.epoch)
+      return {Outcome::Unverified, current_};
+    const auto after = Observe();
+    if (!after.state.known() || after.state.generation != before.state.generation)
+      return {Outcome::Unverified, after};
+    if (applied == ApplyResult::Applied && *after.state.value == desired)
+      return {Outcome::AppliedVerified, after};
+    // Preserve the authoritative readback even when the adapter reports failure.
+    return {applied == ApplyResult::Rejected ? Outcome::Rejected : Outcome::Unverified, after};
+  }
+
+private:
+  void CheckThread() const
+  {
+    if (std::this_thread::get_id() != thread_)
+      throw std::logic_error("setting thread mismatch");
+  }
+  Definition                               definition_;
+  inline static std::atomic<std::uint64_t> next_identity_{1};
+  const std::uint64_t                      identity_ = next_identity_.fetch_add(1);
+  const std::thread::id                    thread_   = std::this_thread::get_id();
+  Snapshot                                 current_;
+  std::uint64_t                            epoch_        = 1;
+  unsigned                                 render_depth_ = 0;
+  bool                                     applying_     = false;
+  bool                                     observing_    = false;
+};
+
+enum class Registration { Added, Duplicate, Invalid, Frozen };
+class BooleanRegistry
+{
+public:
+  Registration Register(Definition definition)
+  {
+    CheckThread();
+    if (frozen_)
+      return Registration::Frozen;
+    if (definition.id.empty() || definition.label.empty() || !definition.read || !definition.write)
+      return Registration::Invalid;
+    if (settings_.contains(definition.id))
+      return Registration::Duplicate;
+    auto id = definition.id;
+    settings_.try_emplace(std::move(id), std::move(definition));
+    return Registration::Added;
+  }
+  BooleanSetting* Find(const std::string& id)
+  {
+    CheckThread();
+    frozen_ = true;
+    auto it = settings_.find(id);
+    return it == settings_.end() ? nullptr : &it->second;
+  }
+  void InvalidateSession()
+  {
+    CheckThread();
+    for (auto& [id, setting] : settings_)
+      setting.InvalidateSession();
+  }
+
+private:
+  void CheckThread() const
+  {
+    if (std::this_thread::get_id() != thread_)
+      throw std::logic_error("registry thread mismatch");
+  }
+  const std::thread::id                 thread_ = std::this_thread::get_id();
+  bool                                  frozen_ = false;
+  std::map<std::string, BooleanSetting> settings_;
+};
+} // namespace mod_settings

--- a/mods/src/settings/boolean_settings.h
+++ b/mods/src/settings/boolean_settings.h
@@ -57,6 +57,17 @@ public:
   const std::string& label() const
   { return definition_.label; }
 
+  // One process-lifetime presentation adapter. Notifications are synchronous,
+  // bounded and run under the write reentry guard; rendering cannot write back.
+  bool SetChangeObserver(void (*observer)())
+  {
+    CheckThread();
+    if (change_observer_ && change_observer_ != observer)
+      return false;
+    change_observer_ = observer;
+    return true;
+  }
+
   class RenderScope
   {
   public:
@@ -142,8 +153,12 @@ public:
         || observed.revision != before.revision || observed.state.generation != before.state.generation
         || observed.state.value != before.state.value)
       return {Outcome::Conflict, before};
-    if (*before.state.value == desired)
+    if (*before.state.value == desired) {
+      NotifyChanged();
+      if (epoch_ != before.epoch)
+        return {Outcome::Unverified, current_};
       return {Outcome::Unchanged, before};
+    }
     ApplyResult applied = ApplyResult::Unverified;
     try {
       applied = definition_.write(desired, before.state.generation);
@@ -154,13 +169,26 @@ public:
     const auto after = Observe();
     if (!after.state.known() || after.state.generation != before.state.generation)
       return {Outcome::Unverified, after};
-    if (applied == ApplyResult::Applied && *after.state.value == desired)
+    if (applied == ApplyResult::Applied && *after.state.value == desired) {
+      NotifyChanged();
+      if (epoch_ != before.epoch)
+        return {Outcome::Unverified, current_};
       return {Outcome::AppliedVerified, after};
+    }
     // Preserve the authoritative readback even when the adapter reports failure.
     return {applied == ApplyResult::Rejected ? Outcome::Rejected : Outcome::Unverified, after};
   }
 
 private:
+  void NotifyChanged()
+  {
+    // Presentation failure does not undo or misreport an authoritative write.
+    try {
+      if (change_observer_)
+        change_observer_();
+    } catch (...) {
+    }
+  }
   void CheckThread() const
   {
     if (std::this_thread::get_id() != thread_)
@@ -175,6 +203,7 @@ private:
   unsigned                                 render_depth_ = 0;
   bool                                     applying_     = false;
   bool                                     observing_    = false;
+  void (*change_observer_)()                             = nullptr;
 };
 
 enum class Registration { Added, Duplicate, Invalid, Frozen };

--- a/mods/src/settings/boolean_view.h
+++ b/mods/src/settings/boolean_view.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "boolean_settings.h"
+
+namespace mod_settings
+{
+// One instance per live view, never a persisted copy of the preference. Native
+// adapters own rendering and invalidate this view before its context is released.
+class BooleanView
+{
+public:
+  explicit BooleanView(BooleanSetting& setting)
+      : setting_(setting)
+  {
+  }
+
+  void Bind()
+  {
+    snapshot_   = setting_.Observe();
+    unresolved_ = !snapshot_.state.known();
+    failed_     = false;
+    bound_      = true;
+  }
+  void Unbind()
+  {
+    snapshot_   = {};
+    bound_      = false;
+    unresolved_ = true;
+    failed_     = false;
+  }
+  void Invalidate()
+  {
+    snapshot_   = {};
+    unresolved_ = true;
+    failed_     = false;
+  }
+  WriteResult Request(bool desired)
+  {
+    if (!editable())
+      return {Outcome::Rejected, snapshot_};
+    auto result = setting_.SetFromUser(desired, snapshot_);
+    if (result.outcome == Outcome::Suppressed || result.outcome == Outcome::Busy)
+      return result;
+    snapshot_   = result.snapshot;
+    failed_     = result.outcome != Outcome::AppliedVerified && result.outcome != Outcome::Unchanged;
+    unresolved_ = !snapshot_.state.known() || result.outcome == Outcome::Unverified;
+    return result;
+  }
+  bool editable() const
+  { return bound_ && !unresolved_ && snapshot_.state.known(); }
+  bool failed() const
+  { return failed_; }
+  std::optional<bool> value() const
+  { return editable() ? snapshot_.state.value : std::nullopt; }
+  BooleanSetting& setting()
+  { return setting_; }
+
+private:
+  BooleanSetting& setting_;
+  Snapshot        snapshot_;
+  bool            bound_      = false;
+  bool            unresolved_ = true;
+  bool            failed_     = false;
+};
+} // namespace mod_settings

--- a/mods/src/settings/native_boolean_callback.h
+++ b/mods/src/settings/native_boolean_callback.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <cstddef>
+#include <il2cpp-class-internals.h>
+#include <il2cpp-tabledefs.h>
+#include <type_traits>
+#include <utility>
+
+namespace mod_settings
+{
+// Process-lifetime schema, owned by the registration, not a settings page. The
+// donor supplies only matching reflection metadata; every executable path is
+// replaced. Never modify a MethodInfo owned by IL2CPP.
+template <typename Result, typename... Args> class NativeCallback
+{
+public:
+  using Function                                   = Result (*)(Il2CppObject*, Args..., const MethodInfo*);
+  NativeCallback()                                 = default;
+  NativeCallback(const NativeCallback&)            = delete;
+  NativeCallback& operator=(const NativeCallback&) = delete;
+  bool            Initialize(const MethodInfo* schema, Function callback)
+  {
+    if (initialized_ || !schema || !callback || schema->is_generic || schema->is_inflated
+        || schema->has_full_generic_sharing_signature || (schema->flags & METHOD_ATTRIBUTE_STATIC)
+        || (schema->flags & METHOD_ATTRIBUTE_VIRTUAL) || schema->parameters_count != sizeof...(Args))
+      return false;
+    if (!schema->return_type || schema->return_type->byref)
+      return false;
+    if constexpr (std::is_void_v<Result>) {
+      if (schema->return_type->type != IL2CPP_TYPE_VOID)
+        return false;
+    } else if constexpr (std::is_same_v<Result, bool>) {
+      if (schema->return_type->type != IL2CPP_TYPE_BOOLEAN)
+        return false;
+    } else {
+      static_assert(std::is_same_v<Result, int>, "Only boolean, void and OptionState callbacks are supported");
+      // The native adapter additionally validates this as an Int32-backed enum.
+      if (schema->return_type->type != IL2CPP_TYPE_VALUETYPE)
+        return false;
+    }
+    static_assert((std::is_same_v<Args, bool> && ...), "Only boolean callback arguments are supported");
+    for (std::size_t i = 0; i < sizeof...(Args); ++i)
+      if (!schema->parameters || !schema->parameters[i] || schema->parameters[i]->byref
+          || schema->parameters[i]->type != IL2CPP_TYPE_BOOLEAN)
+        return false;
+    method_                      = *schema;
+    method_.methodPointer        = reinterpret_cast<Il2CppMethodPointer>(callback);
+    method_.virtualMethodPointer = method_.methodPointer;
+    method_.invoker_method       = Invoke;
+    initialized_                 = true;
+    return true;
+  }
+  const MethodInfo* method() const
+  { return initialized_ ? &method_ : nullptr; }
+
+private:
+  template <std::size_t... I>
+  static void Call(const MethodInfo* method, void* object, void** args, void* result, std::index_sequence<I...>)
+  {
+    auto callback = reinterpret_cast<Function>(method->methodPointer);
+    if constexpr (std::is_void_v<Result>)
+      callback(static_cast<Il2CppObject*>(object), *static_cast<Args*>(args[I])..., method);
+    else
+      *static_cast<Result*>(result) =
+          callback(static_cast<Il2CppObject*>(object), *static_cast<Args*>(args[I])..., method);
+  }
+  static void Invoke(Il2CppMethodPointer, const MethodInfo* method, void* object, void** args, void* result)
+  { Call(method, object, args, result, std::index_sequence_for<Args...>{}); }
+  MethodInfo method_{};
+  bool       initialized_ = false;
+};
+} // namespace mod_settings

--- a/tests/boolean_settings_test.cc
+++ b/tests/boolean_settings_test.cc
@@ -1,0 +1,194 @@
+#include "settings/boolean_settings.h"
+#include <cstdlib>
+#include <iostream>
+
+using namespace mod_settings;
+#define CHECK(x)                                                                                                       \
+  do {                                                                                                                 \
+    if (!(x)) {                                                                                                        \
+      std::cerr << "FAILED line " << __LINE__ << ": " << #x << '\n';                                                   \
+      std::exit(1);                                                                                                    \
+    }                                                                                                                  \
+  } while (false)
+
+struct Fake {
+  bool                  value = false, available = true, reject = false, fail_readback = false, throw_write = false;
+  unsigned              reads = 0, writes = 0;
+  std::uint64_t         generation = 1;
+  std::function<void()> on_read, on_write;
+  Definition            definition(std::string id = "test.confirm")
+  {
+    return {std::move(id), "[MOD] Confirm test",
+            [this] {
+              ++reads;
+              if (on_read)
+                on_read();
+              return available ? ReadResult::Known(value, generation) : ReadResult{};
+            },
+            [this](bool desired, std::uint64_t expected) {
+              ++writes;
+              CHECK(expected == generation);
+              if (on_write)
+                on_write();
+              if (throw_write)
+                throw std::runtime_error("write");
+              if (reject)
+                return ApplyResult::Rejected;
+              value = desired;
+              if (fail_readback)
+                available = false;
+              return ApplyResult::Applied;
+            }};
+  }
+};
+
+int main()
+{
+  {
+    Fake            f;
+    BooleanRegistry registry;
+    CHECK(registry.Register(f.definition()) == Registration::Added);
+    CHECK(registry.Register(f.definition()) == Registration::Duplicate);
+    CHECK(registry.Register({}) == Registration::Invalid);
+    CHECK(f.reads == 0 && f.writes == 0); // Construction schedules no work.
+    auto* s = registry.Find("test.confirm");
+    CHECK(s);
+    CHECK(registry.Register(f.definition("late")) == Registration::Frozen);
+    CHECK(!registry.Find("missing"));
+    auto initial = s->Observe();
+    CHECK(initial.state.known() && !*initial.state.value);
+    CHECK(s->SetFromUser(false, initial).outcome == Outcome::Unchanged);
+    CHECK(f.writes == 0);
+    auto result = s->SetFromUser(true, initial);
+    CHECK(result.outcome == Outcome::AppliedVerified && result.snapshot.state.value == true && f.writes == 1);
+    CHECK(s->SetFromUser(false, initial).outcome == Outcome::Conflict);
+    CHECK(f.writes == 1);
+    CHECK(s->SetFromUser(false, result.snapshot).outcome == Outcome::AppliedVerified);
+    CHECK(f.writes == 2);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    auto           before = s.Observe();
+    {
+      BooleanSetting::RenderScope outer(s);
+      BooleanSetting::RenderScope inner(s);
+      s.Observe();
+      CHECK(s.SetFromUser(true, before).outcome == Outcome::Suppressed);
+    }
+    CHECK(f.writes == 0);
+    CHECK(s.SetFromUser(true, before).outcome == Outcome::AppliedVerified);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    auto           before = s.Observe();
+    f.on_write            = [&] { CHECK(s.SetFromUser(true, before).outcome == Outcome::Busy); };
+    CHECK(s.SetFromUser(true, before).outcome == Outcome::AppliedVerified);
+    CHECK(f.writes == 1);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    auto           before = s.Observe();
+    f.on_read             = [&] { CHECK(s.SetFromUser(true, before).outcome == Outcome::Busy); };
+    CHECK(s.SetFromUser(true, before).outcome == Outcome::AppliedVerified);
+    CHECK(f.writes == 1);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    auto           before = s.Observe();
+    f.reject              = true;
+    auto result           = s.SetFromUser(true, before);
+    CHECK(result.outcome == Outcome::Rejected && result.snapshot.state.value == false);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    auto           before = s.Observe();
+    f.fail_readback       = true;
+    auto result           = s.SetFromUser(true, before);
+    CHECK(result.outcome == Outcome::Unverified && !result.snapshot.state.value && f.value);
+    CHECK(f.writes == 1); // Never attempt an unverified reverse write.
+    f.available = true;
+    CHECK(s.Observe().state.value == true);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    auto           before = s.Observe();
+    f.throw_write         = true;
+    CHECK(s.SetFromUser(true, before).outcome == Outcome::Unverified);
+    f.throw_write = false;
+    CHECK(s.SetFromUser(true, s.Observe()).outcome == Outcome::AppliedVerified);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    auto           before = s.Observe();
+    f.available           = false;
+    CHECK(!s.Observe().state.value);
+    CHECK(s.SetFromUser(true, before).outcome == Outcome::Rejected);
+    CHECK(f.writes == 0);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    auto           before = s.Observe();
+    ++f.generation;
+    CHECK(s.SetFromUser(true, before).outcome == Outcome::Conflict);
+    CHECK(f.writes == 0);
+    before = s.Observe();
+    s.InvalidateSession();
+    CHECK(s.SetFromUser(true, before).outcome == Outcome::Conflict);
+    CHECK(f.writes == 0);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    auto           before = s.Observe();
+    f.on_write            = [&] { s.InvalidateSession(); };
+    CHECK(s.SetFromUser(true, before).outcome == Outcome::Unverified);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    f.on_read = [&] { s.InvalidateSession(); };
+    CHECK(!s.Observe().state.known());
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition()), other(f.definition("other"));
+    CHECK(s.SetFromUser(true, other.Observe()).outcome == Outcome::Conflict);
+    CHECK(f.writes == 0);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    f.on_read = [&] { CHECK(!s.Observe().state.known()); };
+    CHECK(s.Observe().state.known());
+  }
+  {
+    Definition     malformed{"invalid", "invalid", [] { return ReadResult{Availability::Known, true, 0}; },
+                             [](bool, std::uint64_t) { return ApplyResult::Applied; }};
+    BooleanSetting s(std::move(malformed));
+    CHECK(!s.Observe().state.value);
+  }
+  {
+    Fake           f;
+    BooleanSetting s(f.definition());
+    bool           rejected = false;
+    std::thread    other([&] {
+      try {
+        s.Observe();
+      } catch (const std::logic_error&) {
+        rejected = true;
+      }
+    });
+    other.join();
+    CHECK(rejected && f.reads == 0);
+  }
+  std::cout
+      << "PASS boolean settings: registration, readback, failure, refresh, reentry, generation and thread contracts\n";
+}

--- a/tests/boolean_view_test.cc
+++ b/tests/boolean_view_test.cc
@@ -3,6 +3,19 @@
 #include <iostream>
 
 using namespace mod_settings;
+namespace
+{
+BooleanView*    observedView    = nullptr;
+BooleanSetting* observedSetting = nullptr;
+int             notifications   = 0;
+void            Refresh()
+{
+  ++notifications;
+  observedView->Bind();
+  assert(observedSetting->SetFromUser(false, observedSetting->Observe()).outcome == Outcome::Busy);
+}
+void OtherObserver() {}
+} // namespace
 int main()
 {
   bool           available = true, value = true;
@@ -54,5 +67,18 @@ int main()
   first.Unbind();
   assert(!first.value() && first.Request(false).outcome == Outcome::Rejected);
   assert(writes == count);
+  apply = ApplyResult::Applied;
+  value = false;
+  first.Bind();
+  observedView    = &first;
+  observedSetting = &setting;
+  assert(setting.SetChangeObserver(Refresh));
+  assert(setting.SetChangeObserver(Refresh));
+  assert(!setting.SetChangeObserver(OtherObserver));
+  // Recovery shortcut uses the shared setting directly, outside BooleanView.
+  assert(setting.SetFromUser(true, setting.Observe()).outcome == Outcome::AppliedVerified);
+  assert(first.value() == true && notifications == 1 && writes == count + 1);
+  assert(setting.SetFromUser(true, setting.Observe()).outcome == Outcome::Unchanged);
+  assert(first.value() == true && notifications == 2 && writes == count + 1);
   std::cout << "PASS boolean view: render, stale views, unavailable, uncertain writes and teardown\n";
 }

--- a/tests/boolean_view_test.cc
+++ b/tests/boolean_view_test.cc
@@ -1,0 +1,58 @@
+#include "settings/boolean_view.h"
+#include <cassert>
+#include <iostream>
+
+using namespace mod_settings;
+int main()
+{
+  bool           available = true, value = true;
+  int            writes = 0;
+  ApplyResult    apply  = ApplyResult::Applied;
+  BooleanSetting setting({"test.confirmation", "Confirm test",
+                          [&] { return available ? ReadResult::Known(value, 1) : ReadResult{}; },
+                          [&](bool desired, std::uint64_t) {
+                            ++writes;
+                            if (apply != ApplyResult::Rejected)
+                              value = desired;
+                            return apply;
+                          }});
+  BooleanView    first(setting), second(setting);
+  assert(!first.value() && first.Request(false).outcome == Outcome::Rejected);
+  first.Bind();
+  second.Bind();
+  {
+    BooleanSetting::RenderScope render(setting);
+    assert(first.Request(false).outcome == Outcome::Suppressed);
+    assert(first.value() == true && !first.failed() && writes == 0);
+  }
+  assert(first.Request(false).outcome == Outcome::AppliedVerified);
+  assert(first.value() == false && writes == 1);
+  assert(second.Request(false).outcome == Outcome::Conflict);
+  assert(second.value() == false && second.failed() && writes == 1);
+  second.Bind();
+  assert(!second.failed());
+  apply = ApplyResult::Rejected;
+  assert(first.Request(true).outcome == Outcome::Rejected);
+  assert(first.value() == false && first.failed());
+  apply = ApplyResult::Unverified;
+  assert(first.Request(true).outcome == Outcome::Unverified);
+  assert(!first.value() && !first.editable() && first.failed());
+  auto count = writes;
+  assert(first.Request(false).outcome == Outcome::Rejected && writes == count);
+  first.Bind();
+  assert(first.value() == true);
+  setting.InvalidateSession();
+  first.Invalidate();
+  second.Invalidate();
+  assert(!first.value() && first.Request(false).outcome == Outcome::Rejected);
+  available = false;
+  first.Bind();
+  assert(!first.value());
+  available = true;
+  first.Bind();
+  assert(first.value() == true);
+  first.Unbind();
+  assert(!first.value() && first.Request(false).outcome == Outcome::Rejected);
+  assert(writes == count);
+  std::cout << "PASS boolean view: render, stale views, unavailable, uncertain writes and teardown\n";
+}

--- a/tests/native_boolean_callback_test.cc
+++ b/tests/native_boolean_callback_test.cc
@@ -1,0 +1,62 @@
+#include "settings/native_boolean_callback.h"
+#include <cassert>
+#include <iostream>
+
+namespace
+{
+int  donorCalls = 0, calls = 0;
+bool Donor(Il2CppObject*, const MethodInfo*)
+{
+  ++donorCalls;
+  return false;
+}
+bool Getter(Il2CppObject*, const MethodInfo*)
+{
+  ++calls;
+  return true;
+}
+void Setter(Il2CppObject*, bool value, const MethodInfo*)
+{ calls += value ? 10 : 20; }
+} // namespace
+int main()
+{
+  Il2CppType boolType{}, voidType{};
+  boolType.type = IL2CPP_TYPE_BOOLEAN;
+  voidType.type = IL2CPP_TYPE_VOID;
+  MethodInfo schema{};
+  schema.return_type          = &boolType;
+  schema.methodPointer        = reinterpret_cast<Il2CppMethodPointer>(Donor);
+  schema.virtualMethodPointer = schema.methodPointer;
+  mod_settings::NativeCallback<bool> get;
+  assert(get.Initialize(&schema, Getter));
+  assert(!get.Initialize(&schema, Getter));
+  assert(schema.methodPointer == reinterpret_cast<Il2CppMethodPointer>(Donor));
+  auto* owned  = get.method();
+  auto  direct = reinterpret_cast<decltype(&Getter)>(owned->methodPointer);
+  assert(direct(nullptr, owned));
+  auto virt = reinterpret_cast<decltype(&Getter)>(owned->virtualMethodPointer);
+  assert(virt(nullptr, owned));
+  bool value = false;
+  owned->invoker_method(schema.methodPointer, owned, nullptr, nullptr, &value);
+  assert(value && calls == 3 && donorCalls == 0);
+  schema.return_type             = &voidType;
+  const Il2CppType* parameters[] = {&boolType};
+  schema.parameters_count        = 1;
+  schema.parameters              = parameters;
+  mod_settings::NativeCallback<void, bool> set;
+  assert(set.Initialize(&schema, Setter));
+  void* args[] = {&value};
+  owned        = set.method();
+  owned->invoker_method(nullptr, owned, nullptr, args, nullptr);
+  assert(calls == 13 && donorCalls == 0);
+  mod_settings::NativeCallback<bool> invalid;
+  assert(!invalid.Initialize(&schema, Getter));
+  schema.parameters_count = 0;
+  schema.return_type      = &boolType;
+  schema.flags            = METHOD_ATTRIBUTE_VIRTUAL;
+  assert(!invalid.Initialize(&schema, Getter));
+  schema.flags       = 0;
+  schema.is_inflated = true;
+  assert(!invalid.Initialize(&schema, Getter));
+  std::cout << "PASS owned callback: direct, virtual and runtime invoker paths; donor remains untouched\n";
+}

--- a/xmake-packages/packages/s/spud/spud-src/CMakeLists.txt
+++ b/xmake-packages/packages/s/spud/spud-src/CMakeLists.txt
@@ -217,6 +217,8 @@ target_sources(
         "src/detour/detour.cc"
         "src/detour/detour_impl.h"
         "src/detour/fwd.h"
+        "src/detour/target_registry.cc"
+        "src/detour/target_registry.h"
         "src/detour/remapper.cc"
         "src/detour/remapper.h"
         "src/memory/protection.cc"
@@ -238,7 +240,7 @@ if(NOT SPUD_NO_INSTALL)
     )
 endif()
 if(SPUD_BUILD_TESTS)
-    set(TEST_SRCS "tests/signature.cc")
+    set(TEST_SRCS "tests/detour_registry.cc")
     file(
         GLOB_RECURSE TEST_DETOUR_SHARED_SRCS
         tests/detour/shared/*.cc
@@ -306,35 +308,35 @@ if(SPUD_BUILD_TESTS)
     add_executable(
         "spud.test"
         ${TEST_SRCS}
-        "tests/test_util.h"
-        "tests/signature.cc"
     )
-    target_include_directories("spud.test" PRIVATE "tests")
+    target_include_directories("spud.test" PRIVATE "tests" "src")
     target_link_libraries(
         "spud.test"
         PRIVATE "Catch2" "Catch2::Catch2WithMain" "spud"
     )
     add_dependencies("spud.test" "Catch2" "spud")
-    add_executable("spud.benchmark" ${BENCHMARK_SRCS})
-    target_include_directories("spud.benchmark" PRIVATE "benchmark")
-    if(SPUD_COMPARE_LIBS)
-        target_link_libraries(
-            "spud.benchmark"
-            PRIVATE
-                "Catch2"
-                "Catch2::Catch2WithMain"
-                "spud"
-                "lime"
-                "minhook"
-                "PolyHook2"
-        )
-    else()
-        target_link_libraries(
-            "spud.benchmark"
-            PRIVATE "Catch2" "Catch2::Catch2WithMain" "spud"
-        )
+    if(BENCHMARK_SRCS)
+        add_executable("spud.benchmark" ${BENCHMARK_SRCS})
+        target_include_directories("spud.benchmark" PRIVATE "benchmark")
+        if(SPUD_COMPARE_LIBS)
+            target_link_libraries(
+                "spud.benchmark"
+                PRIVATE
+                    "Catch2"
+                    "Catch2::Catch2WithMain"
+                    "spud"
+                    "lime"
+                    "minhook"
+                    "PolyHook2"
+            )
+        else()
+            target_link_libraries(
+                "spud.benchmark"
+                PRIVATE "Catch2" "Catch2::Catch2WithMain" "spud"
+            )
+        endif()
+        add_dependencies("spud.benchmark" "Catch2" "spud")
+        add_test(NAME spud.benchmark COMMAND spud.benchmark)
     endif()
-    add_dependencies("spud.benchmark" "Catch2" "spud")
     add_test(NAME spud.test COMMAND spud.test)
-    add_test(NAME spud.benchmark COMMAND spud.benchmark)
 endif()

--- a/xmake-packages/packages/s/spud/spud-src/include/spud/detour.h
+++ b/xmake-packages/packages/s/spud/spud-src/include/spud/detour.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #if __cpp_lib_source_location && SPUD_DETOUR_TRACING
@@ -17,6 +18,14 @@
 #include "utils.h"
 
 namespace spud {
+
+enum class detour_install_status : uint8_t {
+  not_installed,
+  installed,
+  already_installed,
+  duplicate_target,
+};
+
 namespace detail {
 
 struct detour {
@@ -29,27 +38,23 @@ public:
     return this->trampoline_;
   }
 
+  detour_install_status last_install_status() const {
+    return last_install_status_;
+  }
+
   using Self = detail::detour;
 
 public:
   detour(detour &&other) noexcept {
-    this->trampoline_ = other.trampoline_;
-    this->address_ = other.address_;
-    this->func_ = other.func_;
-    this->wrapper_ = other.wrapper_;
-    this->context_container_ = std::move(other.context_container_);
-    this->original_func_data_ = other.original_func_data_;
-    other.original_func_data_.clear();
+    move_from(std::move(other));
   }
 
   detour &operator=(detour &&other) noexcept {
-    this->trampoline_ = other.trampoline_;
-    this->address_ = other.address_;
-    this->func_ = other.func_;
-    this->wrapper_ = other.wrapper_;
-    this->context_container_ = std::move(other.context_container_);
-    this->original_func_data_ = other.original_func_data_;
-    other.original_func_data_.clear();
+    if (this == &other) {
+      return *this;
+    }
+    remove();
+    move_from(std::move(other));
     return *this;
   }
 
@@ -66,24 +71,19 @@ protected:
 #if __cpp_lib_source_location && SPUD_DETOUR_TRACING
   detour(uintptr_t address, uintptr_t func, uintptr_t wrapper,
          const std::source_location location = std::source_location::current())
-      : address_(address), func_(func), wrapper_(wrapper),
+      : requested_address_(address), address_(address), func_(func),
+        wrapper_(wrapper),
         context_container_(std::make_unique<ContextContainer>()),
         location_(location) {}
 #else
   detour(uintptr_t address, uintptr_t func, uintptr_t wrapper)
-      : address_(address), func_(func), wrapper_(wrapper),
+      : requested_address_(address), address_(address), func_(func),
+        wrapper_(wrapper),
         context_container_(std::make_unique<ContextContainer>()) {}
 #endif
   Self &install(Arch arch = Arch::kHost);
   void remove();
-  Self &detach() {
-    original_func_data_.clear();
-    // We are intentionally ignoring the return value here
-    // TODO(alex): Move this to a global cleanup thing
-    (void)context_container_.release();
-
-    return *this;
-  }
+  Self &detach();
 
   static uintptr_t get_context_value();
 
@@ -91,6 +91,22 @@ private:
   detour(detour const &) = delete;
   detour &operator=(detour const &) = delete;
 
+  void move_from(detour &&other) noexcept {
+    requested_address_ = other.requested_address_;
+    address_ = other.address_;
+    func_ = other.func_;
+    wrapper_ = other.wrapper_;
+    context_container_ = std::move(other.context_container_);
+    trampoline_ = other.trampoline_;
+    original_func_data_ = std::move(other.original_func_data_);
+    installed_ = std::exchange(other.installed_, false);
+    last_install_status_ = other.last_install_status_;
+
+    other.trampoline_ = 0;
+    other.last_install_status_ = detour_install_status::not_installed;
+  }
+
+  uintptr_t requested_address_;
   uintptr_t address_;
   uintptr_t func_;
   uintptr_t wrapper_;
@@ -98,6 +114,9 @@ private:
   std::unique_ptr<struct ContextContainer> context_container_ = nullptr;
   uintptr_t trampoline_ = 0;
   std::vector<uint8_t> original_func_data_ = {};
+  bool installed_ = false;
+  detour_install_status last_install_status_ =
+      detour_install_status::not_installed;
 #if __cpp_lib_source_location && SPUD_DETOUR_TRACING
   const std::source_location location_ = std::source_location::current();
 #endif

--- a/xmake-packages/packages/s/spud/spud-src/include/spud/detour.h
+++ b/xmake-packages/packages/s/spud/spud-src/include/spud/detour.h
@@ -28,7 +28,8 @@ enum class detour_install_status : uint8_t {
 
 using detour_diagnostic_handler = void (*)(const char *message);
 
-// Installs a process-local diagnostic sink. The handler must remain valid until replaced.
+// Installs a process-local diagnostic sink. The handler must have process lifetime; replacement does not wait for
+// concurrent reports. The message is borrowed for the duration of the callback.
 void set_detour_diagnostic_handler(detour_diagnostic_handler handler) noexcept;
 
 namespace detail {

--- a/xmake-packages/packages/s/spud/spud-src/include/spud/detour.h
+++ b/xmake-packages/packages/s/spud/spud-src/include/spud/detour.h
@@ -26,6 +26,11 @@ enum class detour_install_status : uint8_t {
   duplicate_target,
 };
 
+using detour_diagnostic_handler = void (*)(const char *message);
+
+// Installs a process-local diagnostic sink. The handler must remain valid until replaced.
+void set_detour_diagnostic_handler(detour_diagnostic_handler handler) noexcept;
+
 namespace detail {
 
 struct detour {

--- a/xmake-packages/packages/s/spud/spud-src/src/detour/detour.cc
+++ b/xmake-packages/packages/s/spud/spud-src/src/detour/detour.cc
@@ -5,11 +5,14 @@
 
 #include "detour_impl.h"
 #include "remapper.h"
+#include "target_registry.h"
 
 #if SPUD_OS_APPLE
 #include <libkern/OSCacheControl.h>
 #endif
 
+#include <cinttypes>
+#include <cstdio>
 #include <cstring>
 
 #if SPUD_OS_APPLE || SPUD_OS_LINUX
@@ -22,6 +25,24 @@ extern "C" uintptr_t ASM_FUNC(spud_read_context_value, ());
 
 namespace spud {
 namespace detail {
+namespace {
+
+void report_conflict(const target_owner &candidate,
+                     const target_owner &incumbent) noexcept {
+  std::fprintf(
+      stderr,
+      "spud: duplicate detour rejected (requested=0x%" PRIxPTR
+      ", canonical=0x%" PRIxPTR ", replacement=0x%" PRIxPTR
+      "); existing owner requested=0x%" PRIxPTR ", canonical=0x%" PRIxPTR
+      ", replacement=0x%" PRIxPTR ")\n",
+      candidate.requested_address, candidate.canonical_address,
+      candidate.replacement_address, incumbent.requested_address,
+      incumbent.canonical_address, incumbent.replacement_address);
+  std::fflush(stderr);
+}
+
+} // namespace
+
 struct DetourImpl {
   std::vector<uint8_t> (*create_absolute_jump)(uintptr_t target,
                                                uintptr_t data);
@@ -51,84 +72,127 @@ const static std::array<DetourImpl, Arch::kCount> kDetourImpls = {
 };
 
 detail::detour &detour::install(Arch arch) {
+  if (installed_) {
+    last_install_status_ = detour_install_status::already_installed;
+    return *this;
+  }
+  if (context_container_ == nullptr) {
+    last_install_status_ = detour_install_status::not_installed;
+    return *this;
+  }
+
   const auto &impl = kDetourImpls[arch];
 
   // We don't want to hook things that point to a direct jump
   // This will resolve that jump and instead we hook the underlying function
   // func_ = impl.maybe_resolve_jump(func_);
   // TODO(alex): This will break hook stacking most likely right now...
-  address_ = impl.maybe_resolve_jump(address_);
-  wrapper_ = impl.maybe_resolve_jump(wrapper_);
-
-  const auto jump = impl.create_absolute_jump(
-      wrapper_, reinterpret_cast<uintptr_t>(context_container_.get()));
-
-  auto [relocation_infos, required_trampoline_size] =
-      impl.collect_relocations(address_, jump.size());
-
-  // Required trampoline size is how many bytes we have to take up of the
-  // original function This will then be used to calculate the expanded size,
-  // since we do have some instruction replacement and expansion going on
-
-  auto trampoline = impl.create_trampoline(
-      address_ + required_trampoline_size,
-      {reinterpret_cast<uint8_t *>(address_), required_trampoline_size},
-      relocation_infos);
-
-  // TODO(tashcan): This isn't particularly amazing, we might have to ajdust
-  // permissions
-  disable_jit_write_protection();
-
-  auto trampoline_address = alloc_executable_memory(trampoline.data.size());
-  assert(trampoline_address != nullptr);
-
-  std::memcpy(trampoline_address, trampoline.data.data(),
-              trampoline.data.size());
-  trampoline_ =
-      trampoline.start + reinterpret_cast<uintptr_t>(trampoline_address);
-
-  context_container_->func = func_;
-  context_container_->trampoline = trampoline_;
-#if __cpp_lib_source_location && SPUD_DETOUR_TRACING
-  context_container_->location = location_;
-#endif
-
-  {
-    const auto copy_size = required_trampoline_size;
-    original_func_data_.resize(copy_size);
-    std::memcpy(original_func_data_.data(), reinterpret_cast<void *>(address_),
-                copy_size);
-
-    remapper remap(address_, copy_size);
-    {
-      SPUD_SCOPED_PROTECTION(remap, copy_size,
-                             mem_protection::READ_WRITE_EXECUTE);
-
-      // This will leave some trashed instructions
-      // Which is okay for now
-      // TODO(tashcan): Add some kind of NOP function to make the remaining
-      // stuff "valid"
-      std::memcpy(reinterpret_cast<void *>(uintptr_t(remap)), jump.data(),
-                  jump.size());
-#if SPUD_OS_APPLE
-      sys_dcache_flush((void *)address_, copy_size);
-#endif
-    }
-#if SPUD_OS_APPLE
-    sys_icache_invalidate((void *)address_, copy_size);
-#endif
+  const auto canonical_address = impl.maybe_resolve_jump(requested_address_);
+  const target_owner candidate = {
+      .requested_address = requested_address_,
+      .canonical_address = canonical_address,
+      .owner_token = reinterpret_cast<uintptr_t>(context_container_.get()),
+      .replacement_address = func_,
+  };
+  const auto claim = detour_target_registry().claim(candidate);
+  if (claim.status == target_claim_status::conflict) {
+    last_install_status_ = detour_install_status::duplicate_target;
+    report_conflict(candidate, claim.incumbent);
+    return *this;
+  }
+  if (claim.status == target_claim_status::already_owned) {
+    last_install_status_ = detour_install_status::already_installed;
+    return *this;
   }
 
-  enable_jit_write_protection();
+  address_ = canonical_address;
+  wrapper_ = impl.maybe_resolve_jump(wrapper_);
 
+  bool jit_write_protection_disabled = false;
+  try {
+    const auto jump = impl.create_absolute_jump(
+        wrapper_, reinterpret_cast<uintptr_t>(context_container_.get()));
+
+    auto [relocation_infos, required_trampoline_size] =
+        impl.collect_relocations(address_, jump.size());
+
+    // Required trampoline size is how many bytes we have to take up of the
+    // original function This will then be used to calculate the expanded size,
+    // since we do have some instruction replacement and expansion going on
+
+    auto trampoline = impl.create_trampoline(
+        address_ + required_trampoline_size,
+        {reinterpret_cast<uint8_t *>(address_), required_trampoline_size},
+        relocation_infos);
+
+    // TODO(tashcan): This isn't particularly amazing, we might have to adjust
+    // permissions
+    disable_jit_write_protection();
+    jit_write_protection_disabled = true;
+
+    auto trampoline_address = alloc_executable_memory(trampoline.data.size());
+    assert(trampoline_address != nullptr);
+
+    std::memcpy(trampoline_address, trampoline.data.data(),
+                trampoline.data.size());
+    trampoline_ =
+        trampoline.start + reinterpret_cast<uintptr_t>(trampoline_address);
+
+    context_container_->func = func_;
+    context_container_->trampoline = trampoline_;
+#if __cpp_lib_source_location && SPUD_DETOUR_TRACING
+    context_container_->location = location_;
+#endif
+
+    {
+      const auto copy_size = required_trampoline_size;
+      original_func_data_.resize(copy_size);
+      std::memcpy(original_func_data_.data(),
+                  reinterpret_cast<void *>(address_), copy_size);
+
+      remapper remap(address_, copy_size);
+      {
+        SPUD_SCOPED_PROTECTION(remap, copy_size,
+                               mem_protection::READ_WRITE_EXECUTE);
+
+        // This will leave some trashed instructions
+        // Which is okay for now
+        // TODO(tashcan): Add some kind of NOP function to make the remaining
+        // stuff "valid"
+        std::memcpy(reinterpret_cast<void *>(uintptr_t(remap)), jump.data(),
+                    jump.size());
+#if SPUD_OS_APPLE
+        sys_dcache_flush((void *)address_, copy_size);
+#endif
+      }
+#if SPUD_OS_APPLE
+      sys_icache_invalidate((void *)address_, copy_size);
+#endif
+    }
+
+    enable_jit_write_protection();
+    jit_write_protection_disabled = false;
+  } catch (...) {
+    if (jit_write_protection_disabled) {
+      enable_jit_write_protection();
+    }
+    detour_target_registry().release(candidate);
+    original_func_data_.clear();
+    trampoline_ = 0;
+    address_ = requested_address_;
+    throw;
+  }
+
+  installed_ = true;
+  last_install_status_ = detour_install_status::installed;
   return *this;
 }
 
 void detour::remove() {
-  assert(context_container_.get() != nullptr);
-  if (original_func_data_.size() == 0) {
+  if (!installed_ || original_func_data_.empty()) {
     return;
   }
+  assert(context_container_.get() != nullptr);
 
   disable_jit_write_protection();
   {
@@ -143,6 +207,28 @@ void detour::remove() {
   enable_jit_write_protection();
 
   original_func_data_.clear();
+  detour_target_registry().release({
+      .requested_address = requested_address_,
+      .canonical_address = address_,
+      .owner_token = reinterpret_cast<uintptr_t>(context_container_.get()),
+      .replacement_address = func_,
+  });
+  installed_ = false;
+  trampoline_ = 0;
+  address_ = requested_address_;
+  last_install_status_ = detour_install_status::not_installed;
+}
+
+detour::Self &detour::detach() {
+  if (!installed_ || original_func_data_.empty()) {
+    return *this;
+  }
+
+  original_func_data_.clear();
+  // The target remains patched, so both the callback context and target claim
+  // intentionally live until process exit.
+  (void)context_container_.release();
+  return *this;
 }
 
 uintptr_t detour::get_context_value() {

--- a/xmake-packages/packages/s/spud/spud-src/src/detour/detour.cc
+++ b/xmake-packages/packages/s/spud/spud-src/src/detour/detour.cc
@@ -11,6 +11,8 @@
 #include <libkern/OSCacheControl.h>
 #endif
 
+#include <array>
+#include <atomic>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
@@ -24,20 +26,40 @@
 extern "C" uintptr_t ASM_FUNC(spud_read_context_value, ());
 
 namespace spud {
+namespace {
+std::atomic<detour_diagnostic_handler> diagnostic_handler = nullptr;
+}
+
+void set_detour_diagnostic_handler(detour_diagnostic_handler handler) noexcept {
+  diagnostic_handler.store(handler, std::memory_order_release);
+}
+
 namespace detail {
 namespace {
 
 void report_conflict(const target_owner &candidate,
                      const target_owner &incumbent) noexcept {
-  std::fprintf(
-      stderr,
+  std::array<char, 512> message{};
+  std::snprintf(
+      message.data(), message.size(),
       "spud: duplicate detour rejected (requested=0x%" PRIxPTR
       ", canonical=0x%" PRIxPTR ", replacement=0x%" PRIxPTR
       "); existing owner requested=0x%" PRIxPTR ", canonical=0x%" PRIxPTR
-      ", replacement=0x%" PRIxPTR ")\n",
+      ", replacement=0x%" PRIxPTR ")",
       candidate.requested_address, candidate.canonical_address,
       candidate.replacement_address, incumbent.requested_address,
       incumbent.canonical_address, incumbent.replacement_address);
+
+  if (const auto handler = diagnostic_handler.load(std::memory_order_acquire);
+      handler != nullptr) {
+    try {
+      handler(message.data());
+      return;
+    } catch (...) {
+    }
+  }
+
+  std::fprintf(stderr, "%s\n", message.data());
   std::fflush(stderr);
 }
 

--- a/xmake-packages/packages/s/spud/spud-src/src/detour/target_registry.cc
+++ b/xmake-packages/packages/s/spud/spud-src/src/detour/target_registry.cc
@@ -1,0 +1,78 @@
+#include "target_registry.h"
+
+#include <array>
+
+namespace spud::detail
+{
+
+namespace
+{
+  std::array<uintptr_t, 2> target_keys(const target_owner &owner)
+  { return {owner.requested_address, owner.canonical_address}; }
+} // namespace
+
+target_claim_result target_registry::claim(const target_owner &candidate)
+{
+  std::lock_guard lock(mutex_);
+  bool            owner_seen = false;
+
+  for (const auto key : target_keys(candidate)) {
+    const auto entry = targets_.find(key);
+    if (entry == targets_.end()) {
+      continue;
+    }
+    if (entry->second.owner_token != candidate.owner_token) {
+      return {target_claim_status::conflict, entry->second};
+    }
+    owner_seen = true;
+  }
+  if (owner_seen) {
+    return {target_claim_status::already_owned, {}};
+  }
+
+  std::array<uintptr_t, 2> inserted{};
+  size_t                   inserted_count = 0;
+  try {
+    for (const auto key : target_keys(candidate)) {
+      if (targets_.contains(key)) {
+        continue;
+      }
+      targets_.emplace(key, candidate);
+      inserted[inserted_count++] = key;
+    }
+  } catch (...) {
+    for (size_t index = 0; index < inserted_count; ++index) {
+      targets_.erase(inserted[index]);
+    }
+    throw;
+  }
+
+  return {target_claim_status::claimed, {}};
+}
+
+void target_registry::release(const target_owner &owner)
+{
+  std::lock_guard lock(mutex_);
+  for (const auto key : target_keys(owner)) {
+    const auto entry = targets_.find(key);
+    if (entry != targets_.end() && entry->second.owner_token == owner.owner_token) {
+      targets_.erase(entry);
+    }
+  }
+}
+
+size_t target_registry::size() const
+{
+  std::lock_guard lock(mutex_);
+  return targets_.size();
+}
+
+target_registry &detour_target_registry()
+{
+  // Detours can be destroyed during static teardown, so the registry must
+  // intentionally outlive every static detour object.
+  static auto *registry = new target_registry();
+  return *registry;
+}
+
+} // namespace spud::detail

--- a/xmake-packages/packages/s/spud/spud-src/src/detour/target_registry.h
+++ b/xmake-packages/packages/s/spud/spud-src/src/detour/target_registry.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+
+namespace spud::detail
+{
+
+struct target_owner {
+  uintptr_t requested_address;
+  uintptr_t canonical_address;
+  uintptr_t owner_token;
+  uintptr_t replacement_address;
+};
+
+enum class target_claim_status {
+  claimed,
+  already_owned,
+  conflict,
+};
+
+struct target_claim_result {
+  target_claim_status status;
+  target_owner        incumbent{};
+};
+
+class target_registry
+{
+public:
+  target_claim_result claim(const target_owner &candidate);
+  void                release(const target_owner &owner);
+  size_t              size() const;
+
+private:
+  mutable std::mutex                          mutex_;
+  std::unordered_map<uintptr_t, target_owner> targets_;
+};
+
+target_registry &detour_target_registry();
+
+} // namespace spud::detail

--- a/xmake-packages/packages/s/spud/spud-src/tests/detour_registry.cc
+++ b/xmake-packages/packages/s/spud/spud-src/tests/detour_registry.cc
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <barrier>
+#include <string>
 #include <thread>
 #include <utility>
 
@@ -29,6 +30,11 @@ SPUD_TEST_NOINLINE int reinstall_target(int value)
 
 SPUD_TEST_NOINLINE int detached_target(int value)
 { return value + 4; }
+
+std::string last_diagnostic;
+
+void capture_diagnostic(const char *message)
+{ last_diagnostic = message; }
 
 int add_ten(int (*original)(int), int value)
 { return original(value) + 10; }
@@ -123,8 +129,12 @@ TEST_CASE("duplicate detour preserves the first installed hook")
     REQUIRE(call_target(1) == 12);
 
     auto second = spud::create_detour(&duplicate_target, &add_twenty);
+    last_diagnostic.clear();
+    spud::set_detour_diagnostic_handler(&capture_diagnostic);
     second.install();
+    spud::set_detour_diagnostic_handler(nullptr);
     REQUIRE(second.last_install_status() == spud::detour_install_status::duplicate_target);
+    REQUIRE(last_diagnostic.find("duplicate detour rejected") != std::string::npos);
     REQUIRE(second.trampoline() == nullptr);
     REQUIRE(call_target(1) == 12);
   }

--- a/xmake-packages/packages/s/spud/spud-src/tests/detour_registry.cc
+++ b/xmake-packages/packages/s/spud/spud-src/tests/detour_registry.cc
@@ -1,0 +1,180 @@
+#include <spud/detour.h>
+
+#include "detour/target_registry.h"
+
+#include <atomic>
+#include <barrier>
+#include <thread>
+#include <utility>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+
+#if defined(_MSC_VER)
+#define SPUD_TEST_NOINLINE __declspec(noinline)
+#else
+#define SPUD_TEST_NOINLINE __attribute__((noinline))
+#endif
+
+SPUD_TEST_NOINLINE int duplicate_target(int value)
+{ return value + 1; }
+
+SPUD_TEST_NOINLINE int move_target(int value)
+{ return value + 2; }
+
+SPUD_TEST_NOINLINE int reinstall_target(int value)
+{ return value + 3; }
+
+SPUD_TEST_NOINLINE int detached_target(int value)
+{ return value + 4; }
+
+int add_ten(int (*original)(int), int value)
+{ return original(value) + 10; }
+
+int add_twenty(int (*original)(int), int value)
+{ return original(value) + 20; }
+
+} // namespace
+
+TEST_CASE("target registry rejects exact and canonical aliases")
+{
+  spud::detail::target_registry    registry;
+  const spud::detail::target_owner first = {
+      .requested_address   = 0x1000,
+      .canonical_address   = 0x2000,
+      .owner_token         = 0x3000,
+      .replacement_address = 0x4000,
+  };
+
+  REQUIRE(registry.claim(first).status == spud::detail::target_claim_status::claimed);
+  REQUIRE(registry.size() == 2);
+  REQUIRE(registry.claim(first).status == spud::detail::target_claim_status::already_owned);
+
+  const auto exact = registry.claim({
+      .requested_address   = first.requested_address,
+      .canonical_address   = 0x5000,
+      .owner_token         = 0x6000,
+      .replacement_address = 0x7000,
+  });
+  REQUIRE(exact.status == spud::detail::target_claim_status::conflict);
+  REQUIRE(exact.incumbent.owner_token == first.owner_token);
+
+  const auto alias = registry.claim({
+      .requested_address   = 0x8000,
+      .canonical_address   = first.canonical_address,
+      .owner_token         = 0x9000,
+      .replacement_address = 0xA000,
+  });
+  REQUIRE(alias.status == spud::detail::target_claim_status::conflict);
+  REQUIRE(alias.incumbent.owner_token == first.owner_token);
+
+  registry.release(first);
+  REQUIRE(registry.size() == 0);
+}
+
+TEST_CASE("target registry admits exactly one concurrent owner")
+{
+  spud::detail::target_registry registry;
+  std::barrier                  start(3);
+  std::atomic_size_t            claimed   = 0;
+  std::atomic_size_t            conflicts = 0;
+
+  const auto contender = [&](uintptr_t owner) {
+    start.arrive_and_wait();
+    const auto result = registry.claim({
+        .requested_address   = 0x1000,
+        .canonical_address   = 0x2000,
+        .owner_token         = owner,
+        .replacement_address = owner + 1,
+    });
+    if (result.status == spud::detail::target_claim_status::claimed) {
+      claimed.fetch_add(1, std::memory_order_relaxed);
+    } else if (result.status == spud::detail::target_claim_status::conflict) {
+      conflicts.fetch_add(1, std::memory_order_relaxed);
+    }
+  };
+
+  std::thread first(contender, 0x3000);
+  std::thread second(contender, 0x4000);
+  start.arrive_and_wait();
+  first.join();
+  second.join();
+
+  REQUIRE(claimed.load(std::memory_order_relaxed) == 1);
+  REQUIRE(conflicts.load(std::memory_order_relaxed) == 1);
+  REQUIRE(registry.size() == 2);
+}
+
+TEST_CASE("duplicate detour preserves the first installed hook")
+{
+  int (*volatile call_target)(int) = duplicate_target;
+  REQUIRE(call_target(1) == 2);
+
+  {
+    auto first = spud::create_detour(&duplicate_target, &add_ten);
+    first.install();
+    REQUIRE(first.last_install_status() == spud::detour_install_status::installed);
+    REQUIRE(call_target(1) == 12);
+
+    first.install();
+    REQUIRE(first.last_install_status() == spud::detour_install_status::already_installed);
+    REQUIRE(call_target(1) == 12);
+
+    auto second = spud::create_detour(&duplicate_target, &add_twenty);
+    second.install();
+    REQUIRE(second.last_install_status() == spud::detour_install_status::duplicate_target);
+    REQUIRE(second.trampoline() == nullptr);
+    REQUIRE(call_target(1) == 12);
+  }
+  REQUIRE(call_target(1) == 2);
+}
+
+TEST_CASE("moving an installed detour preserves ownership and cleanup")
+{
+  int (*volatile call_target)(int) = move_target;
+  REQUIRE(call_target(1) == 3);
+  {
+    auto source = spud::create_detour(&move_target, &add_ten);
+    source.install();
+    auto moved = std::move(source);
+    REQUIRE(moved.last_install_status() == spud::detour_install_status::installed);
+    REQUIRE(call_target(1) == 13);
+  }
+  REQUIRE(call_target(1) == 3);
+}
+
+TEST_CASE("normal destruction releases a target for later installation")
+{
+  int (*volatile call_target)(int) = reinstall_target;
+  {
+    auto first = spud::create_detour(&reinstall_target, &add_ten);
+    first.install();
+    REQUIRE(first.last_install_status() == spud::detour_install_status::installed);
+    REQUIRE(call_target(1) == 14);
+  }
+  REQUIRE(call_target(1) == 4);
+  {
+    auto second = spud::create_detour(&reinstall_target, &add_twenty);
+    second.install();
+    REQUIRE(second.last_install_status() == spud::detour_install_status::installed);
+    REQUIRE(call_target(1) == 24);
+  }
+  REQUIRE(call_target(1) == 4);
+}
+
+TEST_CASE("detached hooks retain their target claim")
+{
+  int (*volatile call_target)(int) = detached_target;
+  {
+    auto first = spud::create_detour(&detached_target, &add_ten);
+    first.install().detach();
+    REQUIRE(call_target(1) == 15);
+  }
+
+  auto second = spud::create_detour(&detached_target, &add_twenty);
+  second.install();
+  REQUIRE(second.last_install_status() == spud::detour_install_status::duplicate_target);
+  REQUIRE(call_target(1) == 15);
+}

--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -126,11 +126,11 @@
             },
             version = "v1.17.0"
         },
-        ["spud v0.2.0-3#f56260b5"] = {
+        ["spud v0.2.0-4#f56260b5"] = {
             repo = {
                 url = "xmake-packages"
             },
-            version = "v0.2.0-3"
+            version = "v0.2.0-4"
         },
         ["toml++#f56260b5"] = {
             repo = {
@@ -273,11 +273,11 @@
             },
             version = "v1.17.0"
         },
-        ["spud v0.2.0-3#f56260b5"] = {
+        ["spud v0.2.0-4#f56260b5"] = {
             repo = {
                 url = "xmake-packages"
             },
-            version = "v0.2.0-3"
+            version = "v0.2.0-4"
         },
         ["toml++#f56260b5"] = {
             repo = {
@@ -384,11 +384,11 @@
             },
             version = "v1.17.0"
         },
-        ["spud v0.2.0-3#f56260b5"] = {
+        ["spud v0.2.0-4#f56260b5"] = {
             repo = {
                 url = "xmake-packages"
             },
-            version = "v0.2.0-3"
+            version = "v0.2.0-4"
         },
         ["toml++#f56260b5"] = {
             repo = {

--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -126,11 +126,11 @@
             },
             version = "v1.17.0"
         },
-        ["spud v0.2.0-4#f56260b5"] = {
+        ["spud v0.2.0-5#f56260b5"] = {
             repo = {
                 url = "xmake-packages"
             },
-            version = "v0.2.0-4"
+            version = "v0.2.0-5"
         },
         ["toml++#f56260b5"] = {
             repo = {
@@ -273,11 +273,11 @@
             },
             version = "v1.17.0"
         },
-        ["spud v0.2.0-4#f56260b5"] = {
+        ["spud v0.2.0-5#f56260b5"] = {
             repo = {
                 url = "xmake-packages"
             },
-            version = "v0.2.0-4"
+            version = "v0.2.0-5"
         },
         ["toml++#f56260b5"] = {
             repo = {
@@ -384,11 +384,11 @@
             },
             version = "v1.17.0"
         },
-        ["spud v0.2.0-4#f56260b5"] = {
+        ["spud v0.2.0-5#f56260b5"] = {
             repo = {
                 url = "xmake-packages"
             },
-            version = "v0.2.0-4"
+            version = "v0.2.0-5"
         },
         ["toml++#f56260b5"] = {
             repo = {

--- a/xmake/dependencies/common.lua
+++ b/xmake/dependencies/common.lua
@@ -20,7 +20,7 @@ add_requires("toml++")
 add_requires("nlohmann_json")
 add_requires("protobuf 35.1")
 add_requires("cpr", {system = false})
-add_requires("spud v0.2.0-3")
+add_requires("spud v0.2.0-4")
 add_requires("libil2cpp")
 add_requires("simdutf", {system = false})
 

--- a/xmake/dependencies/common.lua
+++ b/xmake/dependencies/common.lua
@@ -20,7 +20,7 @@ add_requires("toml++")
 add_requires("nlohmann_json")
 add_requires("protobuf 35.1")
 add_requires("cpr", {system = false})
-add_requires("spud v0.2.0-4")
+add_requires("spud v0.2.0-5")
 add_requires("libil2cpp")
 add_requires("simdutf", {system = false})
 


### PR DESCRIPTION
Adds **[MOD] Confirm Fleet Commander abilities** under **Settings → General → Skip Confirmation Pop-ups**. ON shows confirmations; OFF skips them.

The control reads and updates the game's existing preference and verifies the result. Opening the page does not create or save preferences. This replaces the Ctrl+Alt+F8 recovery shortcut.

Introduces a reusable boolean-settings framework with separate state and native presentation, guarding stale callbacks and writes during rendering. Native UI supports Windows x64 and macOS.

Depends on #251.

The shared setting contracts match the current typed controls. macOS hooks require loaded-image extent and prologue validation before installation.

Validation: Windows release build passed. Mac native fixture and platform build results are tracked in CI.
