### PR TITLE
Start config persistence groundwork with checked startup saves

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,6 +196,16 @@ jobs:
         shell: pwsh
         run: sccache --show-stats
 
+      - name: Test startup config saves
+        shell: pwsh
+        env:
+          PACKAGE_DIR: ${{ steps.xmake_cache_paths.outputs.package_dir }}
+        run: |
+          $header = Get-ChildItem -LiteralPath (Join-Path $env:PACKAGE_DIR 't/toml++') -Recurse -Filter toml.h |
+            Where-Object { $_.Directory.Name -eq 'toml++' } | Select-Object -First 1
+          if (-not $header) { throw 'Built toml++ package not found.' }
+          ./tests/run-config-save.ps1 -TomlInclude $header.Directory.Parent.FullName
+
       - name: Package
         shell: pwsh
         run: |
@@ -476,6 +486,16 @@ jobs:
       - name: Report protobuf compiler cache
         shell: bash
         run: sccache --show-stats
+
+      - name: Test startup config saves
+        shell: bash
+        env:
+          PACKAGE_DIR: ${{ steps.xmake_cache_paths.outputs.package_dir }}
+        run: |
+          set -euo pipefail
+          TOML_HEADER=$(find "$PACKAGE_DIR/t/toml++" -path '*/include/toml++/toml.h' -print -quit)
+          test -n "$TOML_HEADER"
+          bash tests/run-config-save.sh "$(dirname "$(dirname "$TOML_HEADER")")"
 
       - name: Report Swift module cache
         shell: bash

--- a/docs/config-save.md
+++ b/docs/config-save.md
@@ -1,0 +1,33 @@
+# Startup config saves
+
+`Config::Save` writes complete TOML documents for two startup callers: the initial
+default config and the generated runtime snapshot. It keeps `File::MakePath`
+routing and the existing generated-file warning. Save errors are logged once by
+the caller; startup continues with the in-memory configuration.
+
+`SaveConfigDocument` serializes with toml++, parses the output before touching
+disk, exclusively creates a sibling temporary file, checks writing and closing,
+and replaces the destination. No threads, frame callbacks, runtime controls or
+shutdown interception are installed. This is not the preserving TOML editor:
+whole-document saves do not merge concurrent setting changes or preserve comments.
+
+Windows uses `ReplaceFileW` to preserve existing permissions and streams, with a
+temporary backup for its documented partial-failure cases. Initial creation uses
+a non-replacing move. Ordinary failures clean up the temporary file; partial
+replacement failures retain recovery files and report their location. The backup
+name is the reported temporary path plus `.bak`. Recovery is not automatic.
+macOS uses rename after copying the existing permission bits. Extended metadata
+and hard-link identity are not preserved by that path. Existing symlinks are
+resolved before staging. Replacement requires directory permissions in addition
+to any file access checks; it cannot exactly match an in-place overwrite.
+
+Successful close/replacement is not a guarantee against power loss. A forced exit
+can leave a temporary file. No automatic stale-file sweep is installed.
+
+Run the isolated Windows fixtures with `tests/run-config-save.ps1` after the
+normal AX build has installed toml++; `-TomlInclude` can select another include
+directory. Fixtures never access the installed game's files.
+
+Native behavior references:
+- [Windows ReplaceFileW](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-replacefilew)
+- [POSIX rename](https://pubs.opengroup.org/onlinepubs/9799919799/functions/rename.html)

--- a/docs/config-save.md
+++ b/docs/config-save.md
@@ -29,6 +29,11 @@ Run the isolated Windows fixtures with `tests/run-config-save.ps1` after the
 normal AX build has installed toml++; `-TomlInclude` can select another include
 directory. Fixtures never access the installed game's files.
 
+On macOS, run `bash tests/run-config-save.sh TOML_INCLUDE_DIR`. Both native macOS
+CI jobs run these fixtures after the normal build, including permission-bit and
+symlink checks. The failure fixture injects short writes and failed closes at
+compile time; it does not install test controls in the mod.
+
 Native behavior references:
 - [Windows ReplaceFileW](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-replacefilew)
 - [POSIX rename](https://pubs.opengroup.org/onlinepubs/9799919799/functions/rename.html)

--- a/docs/config-save.md
+++ b/docs/config-save.md
@@ -12,8 +12,9 @@ shutdown interception are installed. This is not the preserving TOML editor:
 whole-document saves do not merge concurrent setting changes or preserve comments.
 
 Windows uses `ReplaceFileW` to preserve existing permissions and streams, with a
-temporary backup for its documented partial-failure cases. Initial creation uses
-a non-replacing move. Ordinary failures clean up the temporary file; partial
+temporary backup for its documented partial-failure cases. A missing destination
+falls back to a non-replacing move. The caller's startup existence check is not an
+exclusive create transaction. Ordinary failures clean up the temporary file; partial
 replacement failures retain recovery files and report their location. The backup
 name is the reported temporary path plus `.bak`. Recovery is not automatic.
 macOS uses rename after copying the existing permission bits. Extended metadata

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "config_save.h"
 #include "file.h"
 #include "patches/mapkey.h"
 #include "prime/KeyCode.h"
@@ -93,10 +94,10 @@ Config::Config()
 
 void Config::Save(const toml::table& config, const std::string_view filename, bool apply_warning)
 {
-  std::ofstream config_file;
+  std::ostringstream config_file;
 
   auto config_path = File::MakePath(filename, true);
-  config_file.open(config_path);
+  config_file.exceptions(std::ios::badbit | std::ios::failbit);
 
   if (apply_warning) {
     char defaultFile[255], configFile[255];
@@ -118,8 +119,7 @@ void Config::Save(const toml::table& config, const std::string_view filename, bo
     config_file << "#######################################################################\n\n";
   }
 
-  config_file << config;
-  config_file.close();
+  SaveConfigDocument(config, std::filesystem::path(config_path), config_file.str());
 }
 
 Config& Config::Get()
@@ -1419,7 +1419,11 @@ void Config::Load()
     message << "Creating " << File::Config() << " (default config file)";
     spdlog::warn(message.str());
 
-    Config::Save(parsed, File::Config(), false);
+    try {
+      Config::Save(parsed, File::Config(), false);
+    } catch (const std::exception& error) {
+      spdlog::error("Could not save default config: {}", error.what());
+    }
   }
 
   message.str("");
@@ -1434,7 +1438,11 @@ void Config::Load()
     std::filesystem::remove(FILE_DEF_PARSED);
   }
 
-  Config::Save(parsed, File::Vars());
+  try {
+    Config::Save(parsed, File::Vars());
+  } catch (const std::exception& error) {
+    spdlog::error("Could not save runtime config: {}", error.what());
+  }
 
   std::cout << "\n\n-----------------------------\n\n"
             << parsed << "\n\n-----------------------------\nVersion "

--- a/mods/src/config_save.cc
+++ b/mods/src/config_save.cc
@@ -1,0 +1,91 @@
+#include "config_save.h"
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <sstream>
+#include <stdexcept>
+
+#if _WIN32
+#include <Windows.h>
+#endif
+
+void SaveConfigDocument(const toml::table& config, const std::filesystem::path& path, std::string_view header)
+{
+  // Serialize and validate before opening any file. Values are encoded by toml++,
+  // never interpolated into TOML source. Validate the header too.
+  std::ostringstream output;
+  output.exceptions(std::ios::badbit | std::ios::failbit);
+  output << header << config;
+  const auto bytes = output.str();
+  (void)toml::parse(bytes);
+
+  // Follow existing symlinks as the former ofstream save did. A sibling stays on
+  // the same filesystem. Exclusive creation avoids truncating another save's file.
+  const auto                             destination = std::filesystem::weakly_canonical(path);
+  static std::atomic<unsigned long long> sequence{0};
+  auto                                   temporary = destination;
+  temporary += ".tmp-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()) + "-"
+               + std::to_string(sequence.fetch_add(1, std::memory_order_relaxed));
+
+  // C11 exclusive creation avoids depending on newer libc++ fstream runtime
+  // support on our minimum supported macOS version.
+#if _WIN32
+  std::FILE* file = nullptr;
+  _wfopen_s(&file, temporary.c_str(), L"wbx");
+#else
+  auto* file = std::fopen(temporary.c_str(), "wbx");
+#endif
+  if (!file) {
+    throw std::system_error(errno, std::generic_category(), "could not create temporary config file");
+  }
+
+  bool replacing = false;
+  try {
+    if (std::fwrite(bytes.data(), 1, bytes.size(), file) != bytes.size()) {
+      throw std::system_error(errno, std::generic_category(), "could not write temporary config file");
+    }
+    const auto closed = std::fclose(file); // Includes flushing; failure prevents replacement.
+    file              = nullptr;
+    if (closed != 0) {
+      throw std::system_error(errno, std::generic_category(), "could not close temporary config file");
+    }
+#if _WIN32
+    // Let Windows retain the existing file's permissions and streams. A backup
+    // protects the old contents in ReplaceFile's documented partial-failure cases.
+    auto backup = temporary;
+    backup += ".bak";
+    if (!ReplaceFileW(destination.c_str(), temporary.c_str(), backup.c_str(), 0, nullptr, nullptr)) {
+      auto error = GetLastError();
+      if (error == ERROR_FILE_NOT_FOUND) {
+        // Initial creation must not replace a config created in the meantime.
+        error = MoveFileExW(temporary.c_str(), destination.c_str(), 0) ? ERROR_SUCCESS : GetLastError();
+      }
+      if (error != ERROR_SUCCESS) {
+        replacing = error == ERROR_UNABLE_TO_MOVE_REPLACEMENT || error == ERROR_UNABLE_TO_MOVE_REPLACEMENT_2;
+        throw std::filesystem::filesystem_error(
+            replacing ? "config replacement failed; retain temporary/backup for recovery" : "config replacement failed",
+            temporary, destination, std::error_code(error, std::system_category()));
+      }
+    }
+    std::error_code ignored;
+    std::filesystem::remove(backup, ignored);
+#else
+    // Preserve ordinary permission bits when replacing an existing config.
+    if (std::filesystem::exists(destination)) {
+      std::filesystem::permissions(temporary, std::filesystem::status(destination).permissions());
+    }
+    std::filesystem::rename(temporary, destination);
+#endif
+  } catch (...) {
+    if (file) {
+      std::fclose(file);
+    }
+    std::error_code ignored;
+    if (!replacing) {
+      std::filesystem::remove(temporary, ignored);
+    }
+    throw;
+  }
+}

--- a/mods/src/config_save.cc
+++ b/mods/src/config_save.cc
@@ -11,6 +11,14 @@
 #include <Windows.h>
 #endif
 
+// Compile-time substitutions are used only by the isolated failure fixture.
+#ifndef CONFIG_SAVE_WRITE
+#define CONFIG_SAVE_WRITE std::fwrite
+#endif
+#ifndef CONFIG_SAVE_CLOSE
+#define CONFIG_SAVE_CLOSE std::fclose
+#endif
+
 void SaveConfigDocument(const toml::table& config, const std::filesystem::path& path, std::string_view header)
 {
   // Serialize and validate before opening any file. Values are encoded by toml++,
@@ -43,10 +51,10 @@ void SaveConfigDocument(const toml::table& config, const std::filesystem::path& 
 
   bool replacing = false;
   try {
-    if (std::fwrite(bytes.data(), 1, bytes.size(), file) != bytes.size()) {
+    if (CONFIG_SAVE_WRITE(bytes.data(), 1, bytes.size(), file) != bytes.size()) {
       throw std::system_error(errno, std::generic_category(), "could not write temporary config file");
     }
-    const auto closed = std::fclose(file); // Includes flushing; failure prevents replacement.
+    const auto closed = CONFIG_SAVE_CLOSE(file); // Includes flushing; failure prevents replacement.
     file              = nullptr;
     if (closed != 0) {
       throw std::system_error(errno, std::generic_category(), "could not close temporary config file");
@@ -59,7 +67,8 @@ void SaveConfigDocument(const toml::table& config, const std::filesystem::path& 
     if (!ReplaceFileW(destination.c_str(), temporary.c_str(), backup.c_str(), 0, nullptr, nullptr)) {
       auto error = GetLastError();
       if (error == ERROR_FILE_NOT_FOUND) {
-        // Initial creation must not replace a config created in the meantime.
+        // Missing-destination fallback: do not overwrite a file appearing before
+        // this move. The caller's earlier existence check is not a create-only transaction.
         error = MoveFileExW(temporary.c_str(), destination.c_str(), 0) ? ERROR_SUCCESS : GetLastError();
       }
       if (error != ERROR_SUCCESS) {

--- a/mods/src/config_save.h
+++ b/mods/src/config_save.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <filesystem>
+#include <string_view>
+#include <toml++/toml.h>
+
+// Synchronous whole-document output for startup, not a runtime setting editor.
+// Throws on failure; the caller owns reporting. Does not guarantee power-loss durability.
+void SaveConfigDocument(const toml::table& config, const std::filesystem::path& path, std::string_view header = {});

--- a/tests/config_save_failure_test.cc
+++ b/tests/config_save_failure_test.cc
@@ -1,0 +1,60 @@
+#include <cerrno>
+#include <cstdio>
+
+static bool failClose = false;
+
+static std::size_t ShortWrite(const void* data, std::size_t size, std::size_t count, std::FILE* file)
+{
+  if (failClose) {
+    return std::fwrite(data, size, count, file);
+  }
+  const auto written = std::fwrite(data, size, count / 2, file);
+  errno              = ENOSPC;
+  return written;
+}
+
+static int FailedClose(std::FILE* file)
+{
+  std::fclose(file);
+  errno = ENOSPC;
+  return EOF;
+}
+
+// Exercise the production cleanup path without adding runtime injection controls.
+#define CONFIG_SAVE_WRITE ShortWrite
+#define CONFIG_SAVE_CLOSE FailedClose
+#include "../mods/src/config_save.cc"
+
+#include <cassert>
+#include <fstream>
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+  assert(argc == 2);
+  const std::filesystem::path root(argv[1]);
+  std::filesystem::create_directories(root);
+  const auto        path     = root / "settings.toml";
+  const std::string original = "# keep this exactly\nenabled = false\n";
+  {
+    std::ofstream out(path, std::ios::binary);
+    out << original;
+  }
+  for (bool closeFailure : {false, true}) {
+    failClose   = closeFailure;
+    bool failed = false;
+    try {
+      SaveConfigDocument(toml::table{{"enabled", true}}, path);
+    } catch (const std::system_error&) {
+      failed = true;
+    }
+    assert(failed);
+    std::ifstream     input(path, std::ios::binary);
+    const std::string actual(std::istreambuf_iterator<char>{input}, {});
+    assert(actual == original);
+    for (const auto& entry : std::filesystem::directory_iterator(root)) {
+      assert(entry.path() == path);
+    }
+  }
+  std::cout << "Short-write and failed-close fixtures passed\n";
+}

--- a/tests/config_save_test.cc
+++ b/tests/config_save_test.cc
@@ -56,6 +56,16 @@ int main(int argc, char** argv)
   CloseHandle(handle);
   assert(failed);
   assert(toml::parse_file(path.string())["enabled"].value<bool>() == true);
+#else
+  const auto mode = std::filesystem::perms::owner_read | std::filesystem::perms::owner_write;
+  std::filesystem::permissions(path, mode);
+  const auto link = root / "linked.toml";
+  std::filesystem::create_symlink(path, link);
+  config.insert_or_assign("enabled", false);
+  SaveConfigDocument(config, link);
+  assert(std::filesystem::is_symlink(link));
+  assert(toml::parse_file(path.string())["enabled"].value<bool>() == false);
+  assert(std::filesystem::status(path).permissions() == mode);
 #endif
   for (const auto& entry : std::filesystem::directory_iterator(root)) {
     assert(entry.path().filename().string().find(".tmp-") == std::string::npos);

--- a/tests/config_save_test.cc
+++ b/tests/config_save_test.cc
@@ -1,0 +1,64 @@
+#include "config_save.h"
+
+#include <cassert>
+#include <fstream>
+#include <iostream>
+
+#if _WIN32
+#include <Windows.h>
+#endif
+
+int main(int argc, char** argv)
+{
+  assert(argc == 2);
+  const std::filesystem::path root(argv[1]);
+  std::filesystem::create_directories(root);
+  const auto        path  = root / "settings.toml";
+  const std::string value = "quotes: \"'\\\n[unexpected]\nenabled = true\nUnicode: \xc3\xa9";
+  toml::table       config{{"value", value}, {"enabled", false}};
+  SaveConfigDocument(config, path, "# generated\n");
+  auto parsed = toml::parse_file(path.string());
+  assert(parsed["value"].value<std::string>() == value);
+  assert(parsed.size() == 2);
+  config.insert_or_assign("enabled", true);
+  SaveConfigDocument(config, path);
+  assert(toml::parse_file(path.string())["enabled"].value<bool>() == true);
+
+  bool failed = false;
+  try {
+    SaveConfigDocument(config, path, "invalid = [\n");
+  } catch (const std::exception&) {
+    failed = true;
+  }
+  assert(failed);
+  assert(toml::parse_file(path.string())["value"].value<std::string>() == value);
+
+  const auto directory = root / "occupied";
+  std::filesystem::create_directory(directory);
+  failed = false;
+  try {
+    SaveConfigDocument(config, directory);
+  } catch (const std::exception&) {
+    failed = true;
+  }
+  assert(failed && std::filesystem::is_directory(directory));
+#if _WIN32
+  // A real sharing violation must leave the previous readable document intact.
+  auto handle = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr);
+  assert(handle != INVALID_HANDLE_VALUE);
+  failed = false;
+  config.insert_or_assign("enabled", false);
+  try {
+    SaveConfigDocument(config, path);
+  } catch (const std::exception&) {
+    failed = true;
+  }
+  CloseHandle(handle);
+  assert(failed);
+  assert(toml::parse_file(path.string())["enabled"].value<bool>() == true);
+#endif
+  for (const auto& entry : std::filesystem::directory_iterator(root)) {
+    assert(entry.path().filename().string().find(".tmp-") == std::string::npos);
+  }
+  std::cout << "Config save fixtures passed\n";
+}

--- a/tests/run-config-save.ps1
+++ b/tests/run-config-save.ps1
@@ -20,6 +20,26 @@ try {
     $fixtureRoot = Join-Path $repoRoot ('build/config-save-test/' + [guid]::NewGuid())
     & ./build/config-save-test/test.exe $fixtureRoot
     if ($LASTEXITCODE -ne 0) { throw 'Config save regression failed.' }
+    $testFile = Join-Path $fixtureRoot 'settings.toml'
+    $inherited = (Get-Acl -LiteralPath $testFile).Sddl
+    & ./build/config-save-test/test.exe $fixtureRoot
+    if ($LASTEXITCODE -ne 0 -or (Get-Acl -LiteralPath $testFile).Sddl -ne $inherited) {
+        throw 'Inherited ACL regression failed.'
+    }
+    $acl = Get-Acl -LiteralPath $testFile
+    $acl.SetAccessRuleProtection($true, $true)
+    Set-Acl -LiteralPath $testFile -AclObject $acl
+    $explicit = (Get-Acl -LiteralPath $testFile).Sddl
+    & ./build/config-save-test/test.exe $fixtureRoot
+    if ($LASTEXITCODE -ne 0 -or (Get-Acl -LiteralPath $testFile).Sddl -ne $explicit) {
+        throw 'Explicit ACL regression failed.'
+    }
+    & clang++ --driver-mode=cl /std:c++latest /EHsc /MT /Imods/src "/I$TomlInclude" `
+        tests/config_save_failure_test.cc /Febuild/config-save-test/failure-test.exe `
+        /Fobuild/config-save-test/ -Wno-deprecated-literal-operator
+    if ($LASTEXITCODE -ne 0) { throw 'Config failure test compilation failed.' }
+    & ./build/config-save-test/failure-test.exe (Join-Path $fixtureRoot 'failures')
+    if ($LASTEXITCODE -ne 0) { throw 'Config failure regression failed.' }
 } finally {
     Pop-Location
 }

--- a/tests/run-config-save.ps1
+++ b/tests/run-config-save.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+param([string]$TomlInclude)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+try {
+    if (-not $TomlInclude) {
+        $packageRoot = Join-Path $env:LOCALAPPDATA '.xmake/packages/t/toml++'
+        $header = Get-ChildItem -LiteralPath $packageRoot -Recurse -Filter toml.h |
+            Where-Object { $_.Directory.Name -eq 'toml++' } | Select-Object -First 1
+        if (-not $header) { throw 'Build with AX first, or supply -TomlInclude.' }
+        $TomlInclude = $header.Directory.Parent.FullName
+    }
+    New-Item -ItemType Directory -Force build/config-save-test | Out-Null
+    & clang++ --driver-mode=cl /std:c++latest /EHsc /MT /Imods/src "/I$TomlInclude" `
+        tests/config_save_test.cc mods/src/config_save.cc /Febuild/config-save-test/test.exe `
+        /Fobuild/config-save-test/ -Wno-deprecated-literal-operator
+    if ($LASTEXITCODE -ne 0) { throw 'Config save test compilation failed.' }
+    $fixtureRoot = Join-Path $repoRoot ('build/config-save-test/' + [guid]::NewGuid())
+    & ./build/config-save-test/test.exe $fixtureRoot
+    if ($LASTEXITCODE -ne 0) { throw 'Config save regression failed.' }
+} finally {
+    Pop-Location
+}

--- a/tests/run-config-save.ps1
+++ b/tests/run-config-save.ps1
@@ -3,6 +3,18 @@ param([string]$TomlInclude)
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = Split-Path -Parent $PSScriptRoot
+function Get-PermissionState([string]$Path) {
+    $acl = Get-Acl -LiteralPath $Path
+    # Windows can normalize descriptor control bits; compare actual rules,
+    # ownership and inheritance protection rather than serialized SDDL spelling.
+    [ordered]@{
+        Owner = $acl.Owner
+        Group = $acl.Group
+        Protected = $acl.AreAccessRulesProtected
+        Rules = @($acl.Access | Select-Object IdentityReference, FileSystemRights,
+            AccessControlType, IsInherited, InheritanceFlags, PropagationFlags)
+    } | ConvertTo-Json -Depth 5 -Compress
+}
 Push-Location $repoRoot
 try {
     if (-not $TomlInclude) {
@@ -18,20 +30,24 @@ try {
         /Fobuild/config-save-test/ -Wno-deprecated-literal-operator
     if ($LASTEXITCODE -ne 0) { throw 'Config save test compilation failed.' }
     $fixtureRoot = Join-Path $repoRoot ('build/config-save-test/' + [guid]::NewGuid())
-    & ./build/config-save-test/test.exe $fixtureRoot
-    if ($LASTEXITCODE -ne 0) { throw 'Config save regression failed.' }
+    # Establish the baseline independently, before the first production save.
+    New-Item -ItemType Directory -Path $fixtureRoot | Out-Null
     $testFile = Join-Path $fixtureRoot 'settings.toml'
-    $inherited = (Get-Acl -LiteralPath $testFile).Sddl
+    Set-Content -LiteralPath $testFile -Value 'enabled = false'
+    if (-not ((Get-Acl -LiteralPath $testFile).Access | Where-Object IsInherited)) {
+        throw 'Fixture must have inherited permission entries.'
+    }
+    $inherited = Get-PermissionState $testFile
     & ./build/config-save-test/test.exe $fixtureRoot
-    if ($LASTEXITCODE -ne 0 -or (Get-Acl -LiteralPath $testFile).Sddl -ne $inherited) {
+    if ($LASTEXITCODE -ne 0 -or (Get-PermissionState $testFile) -ne $inherited) {
         throw 'Inherited ACL regression failed.'
     }
     $acl = Get-Acl -LiteralPath $testFile
     $acl.SetAccessRuleProtection($true, $true)
     Set-Acl -LiteralPath $testFile -AclObject $acl
-    $explicit = (Get-Acl -LiteralPath $testFile).Sddl
+    $explicit = Get-PermissionState $testFile
     & ./build/config-save-test/test.exe $fixtureRoot
-    if ($LASTEXITCODE -ne 0 -or (Get-Acl -LiteralPath $testFile).Sddl -ne $explicit) {
+    if ($LASTEXITCODE -ne 0 -or (Get-PermissionState $testFile) -ne $explicit) {
         throw 'Explicit ACL regression failed.'
     }
     & clang++ --driver-mode=cl /std:c++latest /EHsc /MT /Imods/src "/I$TomlInclude" `

--- a/tests/run-config-save.ps1
+++ b/tests/run-config-save.ps1
@@ -30,6 +30,9 @@ try {
         /Fobuild/config-save-test/ -Wno-deprecated-literal-operator
     if ($LASTEXITCODE -ne 0) { throw 'Config save test compilation failed.' }
     $fixtureRoot = Join-Path $repoRoot ('build/config-save-test/' + [guid]::NewGuid())
+    & ./build/config-save-test/test.exe (Join-Path $fixtureRoot 'created')
+    if ($LASTEXITCODE -ne 0) { throw 'Initial config creation regression failed.' }
+    $fixtureRoot = Join-Path $fixtureRoot 'permissions'
     # Establish the baseline independently, before the first production save.
     New-Item -ItemType Directory -Path $fixtureRoot | Out-Null
     $testFile = Join-Path $fixtureRoot 'settings.toml'

--- a/tests/run-config-save.sh
+++ b/tests/run-config-save.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pass the include directory of the toml++ package used by the normal build.
+toml_include="${1:?usage: run-config-save.sh TOML_INCLUDE_DIR}"
+cd "$(dirname "$0")/.."
+mkdir -p build/config-save-test
+test_root="$(mktemp -d "$PWD/build/config-save-test/run-XXXXXX")"
+
+clang++ -std=c++23 -I mods/src -I "$toml_include" \
+  tests/config_save_test.cc mods/src/config_save.cc -o "$test_root/test"
+"$test_root/test" "$test_root/ordinary"
+clang++ -std=c++23 -I mods/src -I "$toml_include" \
+  tests/config_save_failure_test.cc -o "$test_root/failure-test"
+"$test_root/failure-test" "$test_root/failures"


### PR DESCRIPTION
Checks startup configuration output before replacing an existing file, preventing failed or invalid writes from silently replacing the player's configuration.

`Config::Save` validates serialized TOML, checks writing and closing a sibling temporary file, and uses native file replacement. Failures are reported while startup continues with the in-memory configuration. File permissions and recoverable partial-failure files are preserved where supported.

Applies to initial configuration creation and the runtime snapshot. Supersedes #278.
